### PR TITLE
Adds the lib directory to autoload paths in the engine.

### DIFF
--- a/lib/metasploit/credential/engine.rb
+++ b/lib/metasploit/credential/engine.rb
@@ -30,7 +30,6 @@ else
           end
         end
 
-        isolate_namespace(Metasploit::Credential)
       end
     end
   end


### PR DESCRIPTION
#### Verification:
- [ ] Check out the `feature/credentials-ui` branch of Pro, change the `metasploit-credential` ref in the Gemfile to refer to this branch:
  
  ```
  gem 'metasploit-credential', :git => 'github-metasploit-credential:rapid7/metasploit-credential.git', :branch => 'add_lib_to_autoload'
  ```
- [ ] Generate some creds data
  
  ```
  rails runner db/runners/generate_dataset.rb --host-count=100
  ```
- [ ] Start Pro, verify the following URL produces output
  
  ```
  http://localhost:3000/workspaces/<LOADTESTING_WORKPACE_ID>/metasploit/credential/logins.json?core_id=<SOME_VALID_COREID>
  ```
- [ ] Ensure you can refresh the URL multiple times and still get the same output
- [ ] Land this branch and bump the tag version, fix the tag in `feature/credentials-ui`, ensure you can `bundle install`, and commit and push.
