### PR TITLE
Add counter cache for logins to cores

### DIFF
--- a/app/models/metasploit/credential/login.rb
+++ b/app/models/metasploit/credential/login.rb
@@ -14,7 +14,8 @@ class Metasploit::Credential::Login < ActiveRecord::Base
   #   @return [Metasploit::Credential::Core]
   belongs_to :core,
              class_name: 'Metasploit::Credential::Core',
-             inverse_of: :logins
+             inverse_of: :logins,
+             counter_cache: true
 
   # @!attribute service
   #   The service that either accepted the {#core core credential} as valid, invalid, or on which the

--- a/db/migrate/20140520140817_add_logins_counter_cache_to_cores.rb
+++ b/db/migrate/20140520140817_add_logins_counter_cache_to_cores.rb
@@ -1,0 +1,14 @@
+class AddLoginsCounterCacheToCores < ActiveRecord::Migration
+  def self.up
+    add_column :metasploit_credential_cores, :logins_count, :integer, :default => 0
+
+    Metasploit::Credential::Core.reset_column_information
+    Metasploit::Credential::Core.all.each do |c|
+      Metasploit::Credential::Core.reset_counters c.id, :logins
+    end
+  end
+
+  def self.down
+    remove_column :metasploit_credential_cores, :logins_count
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140417140933) do
+ActiveRecord::Schema.define(:version => 20140520140817) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -168,14 +168,15 @@ ActiveRecord::Schema.define(:version => 20140417140933) do
   end
 
   create_table "metasploit_credential_cores", :force => true do |t|
-    t.integer  "origin_id",    :null => false
-    t.string   "origin_type",  :null => false
+    t.integer  "origin_id",                   :null => false
+    t.string   "origin_type",                 :null => false
     t.integer  "private_id"
     t.integer  "public_id"
     t.integer  "realm_id"
-    t.integer  "workspace_id", :null => false
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
+    t.integer  "workspace_id",                :null => false
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
+    t.integer  "logins_count", :default => 0
   end
 
   add_index "metasploit_credential_cores", ["origin_type", "origin_id"], :name => "index_metasploit_credential_cores_on_origin_type_and_origin_id"


### PR DESCRIPTION
[JIRA Issue](https://jira.tor.rapid7.com/browse/MSP-9951)
## Verification steps
- [x] `rake db:migrate` and run specs (only failure should be for "Metasploit::Credential::Version CONSTANTS PREPRELEASE matches the branch relative name")
- [x] point your Gemfile in pro at the `feature/MSP-9951/logins-counter-cache` for `metasploit-credential`, migrate, and ensure you can access `logins_count` off of a core object
