### PR TITLE
Remove net-ssh version check

### DIFF
--- a/app/models/metasploit/credential/ssh_key.rb
+++ b/app/models/metasploit/credential/ssh_key.rb
@@ -76,16 +76,7 @@ class Metasploit::Credential::SSHKey < Metasploit::Credential::Private
       filename = "#{self.class}#data"
       passphrase = nil
 
-      # TODO Update MSF net-ssh to support this parameter.
-      # Handle ask_passphrase parameter added in net-ssh 2.3.0 for specs
-      # and also support MSF's older, patched version:
-      pre_23_netssh = Gem::Version.new(Net::SSH::Version::CURRENT) < Gem::Version.new('2.3.0')
-
-      if pre_23_netssh
-        Net::SSH::KeyFactory.load_data_private_key(data, passphrase, filename)
-      else
-        Net::SSH::KeyFactory.load_data_private_key(data, passphrase, ask_passphrase, filename)
-      end
+      Net::SSH::KeyFactory.load_data_private_key(data, passphrase, ask_passphrase, filename)
     end
   end
 


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-10038
#### Verification Steps
- [x] Make sure https://github.com/rapid7/metasploit-framework-private/pull/80 lands first
- [x] Bundle install in pro,engine, metamodule/firewall_egress
- [x] In pro, set the metasploit-credential gem to point to the checked out branch. (bug/MSP-10038/skip-ssh-passphrase)
- [x] Launch pro and navigate to

```
http://localhost:3000/workspaces/<WORKSPACE_ID>/credentials#
```
- [x] Click the green "+ Add button"
- [x] Click on the "Private(Passwords)" tab and select ssh key from the dropdown
- [x] Select a realm from the "Realm Tab"
- [x] Enter a encrypted SSH Key into the text field and click save (here's a test key to save time):

``` text
-----BEGIN ENCRYPTED PRIVATE KEY-----
MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIMcKDhsVPHkwCAggA
MBQGCCqGSIb3DQMHBAgOHLWAbG0M5QSCBMjOZOcxTyt4BadsJ9m3T+GO/6pLfsDv
eKrgoT1ys6hgg0hbAegAv3tGe4L4q/JdFCTuz5uDefpV6Ka78mpl2CKuBykX1MhF
ggZyTpM8x1xhFvVhIfkSqdAFfJTyAOdSnQ3z6jqgnHdODa7TzytwP+OZbqmXFmOn
BEN7qmn22WZZ6yBW+3hL38Q6J9SwMNc4MOWb2XyG+Evc6NdT1QO5LRirYC1DKf87
iSQ9f3YwWtd8FmsPJLGoEFGxbREmw0M6ZgUynGp6xUdnvD+CqXN852s/Gd8gvliD
AiKEDBTv5RQs6+Lmd6FjSgQhkJ8vzaGGibAHQhxs926wivFuXu6xNUNq39nAEjlI
UwWYFwJCAVS2Hc8HzaA9YBGrEYUN74s145MnFFfwS85iv7Vt4UeOm4oylL8UhURC
JRxLEZSpkX5KYfo3e7VYbwQQk3bQLmhWpXhYkbo0HcErzNrqtlA/6Pvx9Z9JT2Jh
6mwg2ihlL8iKFStkc/wiY6QEdBPYwSHxZgGAr2zbosLd4+fGBbVWA4F3jR4rBYaT
8KuSOOpFHMdb13SOWrDELBcw3wCzw7PZeXCPsy/EaCACejdFP527R3XhhClc4LaZ
jhNynCnaBzxLbBTWR9w+V7m1NoVNqzG7MR7+F4G3U3Ge5sifzvnQ3qdPmif42CZU
qjvF2IMtn+bJ5C+qcgrlLtdX8PfczlEmW/eAZLv5/jqqRr3W0VsYt8VuoajVwArh
sDNp9PGl8zk+RnJ3jD8c5i0E+wcCQBjCHzUh3OlAHrAF4zr5MbBnAC9iVMF4okdf
JvD6nRTSQmpweQvALgXsuOrbX675c9w68sVMzGmGxMO4fxuL53mz/owRqKH3PzXf
P/xkTRcrC5z+YRLC8urj/Hpeq/9pwlvZv48LWXnZy+jV4R9bV8p+kqXHuJPmElPV
TQEO3MoPXjpjqoHTROa07xsxfImFGDW3USP8qqEU+TGnMBCqS0fsO45sa6DhAG5F
AQJLUnRcNpqK+PAhuj6909gRSaeV8KAa49SJVvrGJmHv22flzoBV9wX7iTz1jwzG
rVUDwFHgJRgkKyBWtXOPh1KN5nFo+mnSXwhwK4X9L21PgQzs2TxRJxdZF+llaECY
CBfzU72ARuanXnvgfe/DS5PC8bf7Rw6D5iXxxDwfV9SOHgMFlZRaywbBNM9T+sbk
pai3d7svAf4oNIC6QgJflCEmirHEB+D0bgOmP2Ffl9mX/CYJQaLwjCfJvgoGgnm+
YRi9E/i0wjEAJ17BLqZ0j/RcCnME8d92UptfsxnBpIoDjYchOq3YM3dIpsUZVk0r
Fphp4sq0xAdqh7F9JFsnlPtIJ81n2/O7StwClOaafDVSTVWJ7ya7szW6uFkn+ZqE
X5w/6YS6Ru/KFC8q9UjqqZfeJ6g0t/nMZ2J1G3PXd6eO6lrFIG14wBAdTYZ9OeYz
WN/ARg24PPhaQeIiWcOl3SYHmxwoArBrei59Q9NQd9p/Ot7F01PIeImusu/7aReI
8kEOBtfoJ1+bmAnvZMxn5hfvNXFHk4KlAyEYHrp6vTOpe5D6cVNQIRG4n3J7GgCX
/MfNo7GYDxZVjDvix+QSLfHvSRrm5XwbqAHlFll+/iFKZDaNsdbRa+5VFCpuQRQ4
CZM=
-----END ENCRYPTED PRIVATE KEY-----
```
- [x] Verify you see 

```
is encrypted, but Metasploit::Credential::SSHKey only supports unencrypred private keys.OpenSSL::PKey::RSAError Neither PUB key nor PRIV key:: nested asn1 error
```
- [x] Replace the encrypted ssh key with an unencrypted key and click save. Here's another test key:

``` text
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZJsk26ay+PJH3upSqTSqAYSu9RudPJrTSyaV68BTZt3WAvkWoJz/+rVmWUXHDnroQL/sZeK5yK7iU98/LZnKRsTJNjvF6RbrESHU1CBJbLlz0mZaV0CuGdMdCjO4czsrVtRF/CaRoOUhrk4KAEHylJfIPuYAnj105t3jJbucB1CaWpWnJCIrwB17EbXaCwi0J6n8SmekK9tM0M35ur4X2hzNQsRL7zmiGmlx1aRwIyUO77lBRKoSKXfGblxjMSh3MvvwSs9Lv7XIKtDJLc8UNqXj+HArW+nT3S+NHBll6bHu9D7cmrfgpB657o5IK/dUZhAM0plSGG2HtkHR5sp0f techpeace@AUS-MAC-1089
```
- [x] Verify modal closes and cred appears in table.
