### PR TITLE
Fix gem version to support rubygems < 2.1

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -26,9 +26,27 @@ module Metasploit
 
         version
       end
+
+      # The full gem version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
+      # {http://guides.rubygems.org/specification-reference/#version RubyGems versioning} format.
+      #
+      # @return [String] '{MAJOR}.{MINOR}.{PATCH}' on master.  '{MAJOR}.{MINOR}.{PATCH}.{PRERELEASE}' on any branch
+      #   other than master.
+      def self.gem
+        version = "#{MAJOR}.#{MINOR}.#{PATCH}"
+
+        if defined? PRERELEASE
+          version = "#{version}.#{PRERELEASE.gsub(/[^0-9a-zA-Z]/, '')}"
+        end
+
+        version
+      end
     end
 
     # @see Version.full
     VERSION = Version.full
+
+    # @see Version.gem
+    GEM_VERSION = Version.gem
   end
 end

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -6,7 +6,7 @@ require 'metasploit/credential/version'
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = 'metasploit-credential'
-  s.version     = Metasploit::Credential::VERSION
+  s.version     = Metasploit::Credential::GEM_VERSION
   s.authors     = ['Luke Imhoff', 'Trevor Rosen']
   s.email       = ['luke_imhoff@rapid7.com', 'trevor_rosen@rapid7.com']
   s.homepage    = 'https://github.com/rapid7/metasploit-credential'


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-10714
## Verification Steps
- [ ] `gem update --system 1.8.23`
- [ ] `bundle`
- [ ] VERIFY: bundle completes successfully
## Land
- [ ] Merge this PR
- [ ] Merge: rapid7/metasploit-framework-private#111
