### PR TITLE
fix invalidate_login last_attempted_at

### DIFF
--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -448,8 +448,10 @@ module Metasploit
 
           if login.present?
             login.status = status
+            login.last_attempted_at = DateTime.now
             login.save!
           end
+
         end
 
       end

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,9 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 7
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 0
+      PATCH = 1
       # The prerelease name of the given {MAJOR}.{MINOR}.{PATCH} version number. Will not be defined on master.
-      PRERELEASE = "electro-release"
+      PRERELEASE = "invalidate-login"
 
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the

--- a/spec/lib/metasploit/credential/creation_spec.rb
+++ b/spec/lib/metasploit/credential/creation_spec.rb
@@ -480,5 +480,40 @@ describe Metasploit::Credential::Creation do
     end
     
   end
+
+  context '#invalidate_login' do
+
+    context 'when an untried login exists' do
+      let(:untried_login) { FactoryGirl.create(:metasploit_credential_login, status: Metasploit::Model::Login::Status::UNTRIED)}
+
+      it 'sets the supplied status on that login' do
+        opts = {
+            address: untried_login.service.host.address,
+            port: untried_login.service.port,
+            protocol: untried_login.service.proto,
+            public: untried_login.core.public.username,
+            private: untried_login.core.private.data,
+            realm_key: untried_login.core.realm.try(:key),
+            realm_value: untried_login.core.realm.try(:value),
+            status: Metasploit::Model::Login::Status::INCORRECT
+        }
+        expect{ test_object.invalidate_login(opts) }.to change{untried_login.reload.status}.from(Metasploit::Model::Login::Status::UNTRIED).to(Metasploit::Model::Login::Status::INCORRECT)
+      end
+
+      it 'changes the last_attempted_at timestamp' do
+        opts = {
+            address: untried_login.service.host.address,
+            port: untried_login.service.port,
+            protocol: untried_login.service.proto,
+            public: untried_login.core.public.username,
+            private: untried_login.core.private.data,
+            realm_key: untried_login.core.realm.try(:key),
+            realm_value: untried_login.core.realm.try(:value),
+            status: Metasploit::Model::Login::Status::INCORRECT
+        }
+        expect{ test_object.invalidate_login(opts) }.to change{untried_login.reload.last_attempted_at}
+      end
+    end
+  end
   
 end


### PR DESCRIPTION
invalidate_login now sets last_attempted_at approrpiately

VERIFICATION STEPS
- [x] rake spec
- [x] verify specs pass
# Post-merge Steps
## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Update PRERELEASE to 'electro-release'
## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the prerelease suffix has changed on the gem
- [x] Note the version to use in tagging below
## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures
## Commit, tag, push
- [x] Commit changes to metasploit-credential
- [x] `git tag --message 'Version 0.7.1 on staging/electro-release branch' 'v0.7.1-electro-release'
- [x] `git push`
- [x] `git push --tags`
