### PR TITLE
fix race condition in create credential core

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,7 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 8
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 2
+      PATCH = 3
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
now that core has a uniqueness constraint we have to close
up the race condition.

VERIFICATION STEPS
- [x] point pro to this branch by using path in the gemfile
- [x] start pro
- [ ] create a new project with the following in the network range:

```
creds-2k3sql-01.ms.scanlab.rapid7.com
creds-centos-01.ms.scanlab.rapid7.com
creds-ub1204-01.ms.scanlab.rapid7.com
creds-w28-mssql.ms.scanlab.rapid7.com
creds-w7apps-01.ms.scanlab.rapid7.com
```
- [x] do discovery scan
- [x] select all hosts and run psexec
- [x] use msfadmin:msfadmin
- [x] set payload to bind
- [x] run exploit
- [x] VERIFY you do not get a stack trace with: 
  `Exploit failed: ActiveRecord::RecordNotUnique PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_metasploit_credential_privates_on_type_and_data"
  DETAIL:  Key (type, data)=(Metasploit::Credential::Password, notpassword) already exists.`
# Release

Complete these steps on DESTINATION
## `VERSION`
### Compatible changes

If your change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit/credential/version.rb).
### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment [`MINOR`](lib/metasploit/credential/version.rb) and reset [`PATCH`](lib/metasploit/credential/version.rb) to `0`.
- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update [`MINOR`](lib/metasploit/credential/version.rb) and [`PATCH`](lib/metasploit/credential/version.rb) and commit the changes.
## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`
## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`
