### PR TITLE
put retry blocks around record creations

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,7 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 8
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 7
+      PATCH = 8
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
VERIFICATION STEPS
- [x] pull down this branch
- [x] point pro gemfile to local path
- [x] In pro, `bundle install`
- [x] start pro
- [x] new project
- [x] 10.20.39.0/24 as the network range
- [x] scan all hosts
- [x] run psexec against all hosts, with msfadmin:msfadmin
- [x] VERIFY no activeRecord errors
# Release

Complete these steps on DESTINATION
## `VERSION`
### Compatible changes

If your change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit/credential/version.rb).
### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment [`MINOR`](lib/metasploit/credential/version.rb) and reset [`PATCH`](lib/metasploit/credential/version.rb) to `0`.
- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update [`MINOR`](lib/metasploit/credential/version.rb) and [`PATCH`](lib/metasploit/credential/version.rb) and commit the changes.
## JRuby

Do not release, broken on travis-CI.
## MRI Ruby
- [x] `rvm use ruby-1.9.3-p547@metasploit-credential`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake release`
