### PR TITLE
MSP-11905: add access_level, attempted_at, status attributes to credential export

### DIFF
--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -206,10 +206,10 @@ module Metasploit
           opts[:task_id] ||= self[:task].record.id
         end
 
-        access_level       = opts.fetch(:access_level, nil)
         core               = opts.fetch(:core)
+        access_level       = opts.fetch(:access_level, nil)
         last_attempted_at  = opts.fetch(:last_attempted_at, nil)
-        status             = opts.fetch(:status)
+        status             = opts.fetch(:status, Metasploit::Model::Login::Status::UNTRIED)
 
         login_object = nil
         retry_transaction do

--- a/lib/metasploit/credential/exporter/core.rb
+++ b/lib/metasploit/credential/exporter/core.rb
@@ -122,6 +122,9 @@ class Metasploit::Credential::Exporter::Core
   # The hashes returned by this method will contain credentials for
   # networked devices which may or may not successfully authenticate to those
   # devices.
+  # Note that the order of columns here must match the order in
+  # Metasploit::Credential::Importer::Core::VALID_LONG_CSV_HEADERS or
+  # the headers and row values will be mismatched and break import.
   # @param login [Metasploit::Credential::Login]
   # @return [Hash]
   def line_for_login(login)
@@ -130,7 +133,10 @@ class Metasploit::Credential::Exporter::Core
       host_address: login.service.host.address,
       service_port: login.service.port,
       service_name: login.service.try(:name),
-      service_protocol: login.service.proto
+      service_protocol: login.service.proto,
+      status: login.status,
+      access_level: login.access_level,
+      last_attempted_at: login.last_attempted_at
     })
   end
 

--- a/lib/metasploit/credential/importer/core.rb
+++ b/lib/metasploit/credential/importer/core.rb
@@ -21,7 +21,12 @@ class Metasploit::Credential::Importer::Core
   BLANK_TOKEN = "<BLANK>"
 
   # Valid headers for a CSV containing heterogenous {Metasploit::Credential::Private} types and values for {Metasploit::Credential::Realm}
-  VALID_LONG_CSV_HEADERS = [:username, :private_type, :private_data, :realm_key, :realm_value, :host_address, :service_port, :service_name, :service_protocol]
+  VALID_LONG_CSV_HEADERS = [:username, :private_type, :private_data,
+                            :realm_key, :realm_value, :host_address,
+                            :service_port, :service_name,
+                            :service_protocol, :status, :access_level,
+                            :last_attempted_at
+  ]
 
   # Valid headers for a "short" CSV containing only data for {Metasploit::Credential::Public} and {Metasploit::Credential::Private} objects
   VALID_SHORT_CSV_HEADERS = [:username,  :private_data]
@@ -107,10 +112,13 @@ class Metasploit::Credential::Importer::Core
         private_data  = row['private_data'].present? ? row['private_data'] : ''
 
         # Host and Service information for Logins
-        host_address     = row['host_address']
-        service_port     = row['service_port']
-        service_protocol = row['service_protocol']
-        service_name     = row['service_name']
+        host_address      = row['host_address']
+        service_port      = row['service_port']
+        service_protocol  = row['service_protocol']
+        service_name      = row['service_name']
+        access_level      = row['access_level']
+        last_attempted_at = row['last_attempted_at']
+        status            = row['status']
 
 
         if realms[realm_value].nil?
@@ -145,7 +153,10 @@ class Metasploit::Credential::Importer::Core
             port: service_port,
             protocol: service_protocol,
             workspace_id: workspace.id,
-            service_name: service_name.present? ? service_name : ""
+            service_name: service_name.present? ? service_name : "",
+            status: status,
+            access_level: access_level,
+            last_attempted_at: last_attempted_at
           }
           create_credential_login(login_opts)
         end

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,7 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 9
+      PATCH = 11
       # The prerelease version, scoped to the {PATCH} version number.
       PRERELEASE = 'attempted-at-access-level-add'
 

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 8
+      PATCH = 9
+      # The prerelease version, scoped to the {PATCH} version number.
+      PRERELEASE = 'attempted-at-access-level-add'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/factories/metasploit/credential/importer/cores.rb
+++ b/spec/factories/metasploit/credential/importer/cores.rb
@@ -1,20 +1,23 @@
 FactoryGirl.define do
+  long_form_headers  = 'username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol'
+  short_form_headers = 'username,private_data'
+
   factory :metasploit_credential_core_importer,
           class: Metasploit::Credential::Importer::Core do
-
-    origin {FactoryGirl.build :metasploit_credential_origin_import }
-    input { generate(:well_formed_csv_compliant_header)}
+            origin { FactoryGirl.build :metasploit_credential_origin_import }
+            input  { generate(:well_formed_csv_compliant_header) }
   end
+
 
   # Well-formed CSV
   # Has a compliant header as defined by Metasploit::Credential::Importer::Core
   # Contains 2 realms
   sequence :well_formed_csv_compliant_header do |n|
     csv_string =<<-eos
-username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol
 han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
 princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
 lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
+#{long_form_headers}
     eos
     StringIO.new(csv_string)
   end
@@ -24,10 +27,10 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit:
   # Contains 2 logins
   sequence :well_formed_csv_compliant_header_with_service_info do |n|
     csv_string =<<-eos
-username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol
 han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,10.0.1.1,1234,smb,tcp
 princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,10.0.1.2,1234,smb,tcp
 lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
+#{long_form_headers}
     eos
     StringIO.new(csv_string)
   end
@@ -37,10 +40,10 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit:
   # Contains no realm data
   sequence :well_formed_csv_compliant_header_no_realm do |n|
     csv_string =<<-eos
-username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol
 han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,,
 princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,,
 lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,,
+#{long_form_headers}
     eos
     StringIO.new(csv_string)
   end
@@ -51,10 +54,10 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,,
   # Contains core with a blank Public
   sequence :well_formed_csv_compliant_header_missing_public do |n|
     csv_string =<<-eos
-username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol
 ,#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
 princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
 lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
+#{long_form_headers}
     eos
     StringIO.new(csv_string)
   end
@@ -65,7 +68,7 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit:
   # Contains core with a blank Private
   sequence :well_formed_csv_compliant_header_missing_private do |n|
     csv_string =<<-eos
-username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol
+#{long_form_headers}
 han_solo,,,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
 princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
 lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
@@ -78,7 +81,7 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit:
   # Conforms to "short" form, in which only username and private_data are specified in the file
   sequence :short_well_formed_csv do |n|
     csv_string =<<-eos
-username,private_data
+#{short_form_headers}
 han_solo-#{n},falC0nBaws
 princessl-#{n},bagelHead
     eos
@@ -116,7 +119,7 @@ foo,{"""}
   # We have a header row but nothing else
   sequence :empty_core_csv do |n|
     csv_string =<<-eos
-username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol
+#{long_form_headers}
     eos
     StringIO.new(csv_string)
   end

--- a/spec/factories/metasploit/credential/importer/cores.rb
+++ b/spec/factories/metasploit/credential/importer/cores.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
-  long_form_headers  = 'username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol'
+  long_form_headers  = 'username,private_type,private_data,realm_key,realm_value,host_address,service_port,service_name,service_protocol,status,access_level,last_attempted_at'
   short_form_headers = 'username,private_data'
+  login_status       = Metasploit::Model::Login::Status::ALL.select {|x| x != Metasploit::Model::Login::Status::UNTRIED }.sample
+  access_level       = ['Admin', 'Foo'].sample
+  last_attempted_at  = Time.now - 10
 
   factory :metasploit_credential_core_importer,
           class: Metasploit::Credential::Importer::Core do
@@ -14,10 +17,10 @@ FactoryGirl.define do
   # Contains 2 realms
   sequence :well_formed_csv_compliant_header do |n|
     csv_string =<<-eos
-han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
-princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
-lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
 #{long_form_headers}
+han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,,,,,#{login_status},#{access_level},#{last_attempted_at}
+princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,,,,,#{login_status},#{access_level},#{last_attempted_at}
+lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins,,,,,#{login_status},#{access_level},#{last_attempted_at}
     eos
     StringIO.new(csv_string)
   end
@@ -27,10 +30,10 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit:
   # Contains 2 logins
   sequence :well_formed_csv_compliant_header_with_service_info do |n|
     csv_string =<<-eos
-han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,10.0.1.1,1234,smb,tcp
-princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,10.0.1.2,1234,smb,tcp
-lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
 #{long_form_headers}
+han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,10.0.1.1,1234,smb,tcp,#{login_status},#{access_level},#{last_attempted_at}
+princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,10.0.1.2,1234,smb,tcp,#{login_status},#{access_level},#{last_attempted_at}
+lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins,#{login_status},#{access_level},#{last_attempted_at}
     eos
     StringIO.new(csv_string)
   end
@@ -40,10 +43,10 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit:
   # Contains no realm data
   sequence :well_formed_csv_compliant_header_no_realm do |n|
     csv_string =<<-eos
-han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,,
-princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,,
-lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,,
 #{long_form_headers}
+han_solo-#{n},#{Metasploit::Credential::Password.name},falcon_chief,,,,,,#{login_status},#{access_level},#{last_attempted_at},,,,,#{login_status},#{access_level},#{last_attempted_at}
+princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,,,,,,#{login_status},#{access_level},#{last_attempted_at},,,,,#{login_status},#{access_level},#{last_attempted_at}
+lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,,,,,,#{login_status},#{access_level},#{last_attempted_at},,,,,#{login_status},#{access_level},#{last_attempted_at}
     eos
     StringIO.new(csv_string)
   end
@@ -54,10 +57,10 @@ lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,,
   # Contains core with a blank Public
   sequence :well_formed_csv_compliant_header_missing_public do |n|
     csv_string =<<-eos
-,#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
-princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels
-lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins
 #{long_form_headers}
+,#{Metasploit::Credential::Password.name},falcon_chief,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,,,,,#{login_status},#{access_level},#{last_attempted_at}
+princessl-#{n},#{Metasploit::Credential::Password.name},bagel_head,#{Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN},Rebels,,,,,#{login_status},#{access_level},#{last_attempted_at}
+lord_vader-#{n},#{Metasploit::Credential::Password.name},evilisfun,#{Metasploit::Model::Realm::Key::ORACLE_SYSTEM_IDENTIFIER},dstar_admins,,,,,#{login_status},#{access_level},#{last_attempted_at}
     eos
     StringIO.new(csv_string)
   end

--- a/spec/lib/metasploit/credential/exporter/core_spec.rb
+++ b/spec/lib/metasploit/credential/exporter/core_spec.rb
@@ -87,7 +87,9 @@ describe Metasploit::Credential::Exporter::Core do
       result_hash.values.should == [core.public.username, core.private.type,
                                     core.private.data, core.realm.key, core.realm.value,
                                     login.service.host.address, login.service.port,
-                                    login.service.name, login.service.proto]
+                                    login.service.name, login.service.proto,
+                                    login.status, login.access_level, login.last_attempted_at
+      ]
     end
 
     it 'should produce a hash with the service host address' do
@@ -104,6 +106,18 @@ describe Metasploit::Credential::Exporter::Core do
 
     it 'should produce a hash with the service protocol' do
       result_hash[:service_protocol].should == login.service.proto
+    end
+
+    it 'should produce a hash with the login status' do
+      result_hash[:status].should == login.status
+    end
+
+    it 'should produce a hash with the login access_level' do
+      result_hash[:access_level].should == login.access_level
+    end
+
+    it 'should produce a hash with the login last_attempted_at' do
+      result_hash[:last_attempted_at].should == login.last_attempted_at
     end
 
     it 'should produce a hash with the public information' do

--- a/spec/lib/metasploit/credential/exporter/core_spec.rb
+++ b/spec/lib/metasploit/credential/exporter/core_spec.rb
@@ -59,69 +59,62 @@ describe Metasploit::Credential::Exporter::Core do
   end
 
   describe "#line_for_core" do
+    let(:result_hash) { core_exporter.line_for_core(core) }
+
     it 'should produce values in the proper order' do
-      core_exporter.line_for_core(core).values.should == [core.public.username, core.private.type,
-                                                          core.private.data, core.realm.key, core.realm.value]
+      result_hash.values.should == [core.public.username, core.private.type,
+                                    core.private.data, core.realm.key, core.realm.value]
     end
 
     it 'should produce a hash with the public username' do
-      result_hash = core_exporter.line_for_core(core)
       result_hash[:username].should == core.public.username
     end
 
     it 'should produce a hash with the private data' do
-      result_hash = core_exporter.line_for_core(core)
       result_hash[:private_data].should == core.private.data
     end
 
     it 'should produce a hash with the name of the private type' do
-      result_hash = core_exporter.line_for_core(core)
       result_hash[:private_type].should == core.private.type
     end
   end
 
   describe "#line_for_login" do
     let(:login){ FactoryGirl.create(:metasploit_credential_login, core: core, service: service) }
+    let(:result_hash) { core_exporter.line_for_login(login) }
 
     it 'should produce values in the proper order' do
-      core_exporter.line_for_login(login).values.should == [core.public.username, core.private.type,
-                                                            core.private.data, core.realm.key, core.realm.value,
-                                                            login.service.host.address, login.service.port,
-                                                            login.service.name, login.service.proto]
+      result_hash.values.should == [core.public.username, core.private.type,
+                                    core.private.data, core.realm.key, core.realm.value,
+                                    login.service.host.address, login.service.port,
+                                    login.service.name, login.service.proto]
     end
 
     it 'should produce a hash with the service host address' do
-      result_hash = core_exporter.line_for_login(login)
       result_hash[:host_address].should == login.service.host.address
     end
 
     it 'should produce a hash with the service port' do
-      result_hash = core_exporter.line_for_login(login)
       result_hash[:service_port].should == login.service.port
     end
 
     it 'should produce a hash with the service name' do
-      result_hash = core_exporter.line_for_login(login)
       result_hash[:service_name].should == login.service.name
     end
 
     it 'should produce a hash with the service protocol' do
-      result_hash = core_exporter.line_for_login(login)
       result_hash[:service_protocol].should == login.service.proto
     end
 
     it 'should produce a hash with the public information' do
-      result_hash = core_exporter.line_for_login(login)
       result_hash[:username].should == login.core.public.username
     end
 
     it 'should produce a hash with the private data' do
-      result_hash = core_exporter.line_for_login(login)
       result_hash[:private_data].should == login.core.private.data
     end
 
-    it 'should produce a hash with the demodulized name of the  private type' do
-      result_hash = core_exporter.line_for_login(login)
+    it 'should produce a hash with the demodulized name of the private type' do
       result_hash[:private_type].should == login.core.private.type
     end
   end


### PR DESCRIPTION
The credential export (used in both Manage Credentials export as well as within the Zip Workspace export) was missing several attributes. These are included in export and import now, specs are updated to match, and old exports (without the new columns) are handled properly.

## Steps to verify
- [x] On Pro master, in a workspace with logins (various statuses are desirable, run through these steps to get a good variety: https://github.com/rapid7/pro/pull/1657), generate a Zip Workspace export
- [x] Change Pro Gemfile L48 to: ```gem 'metasploit-credential', :path => '/Users/YOU/rapid7/metasploit-credential'```
- [x] ```bundle```
- [x] Restart foreman, generate another Zip Workspace from the same workspace
- [x] In one new workspace, import the first zip
- [x] Verify you get no errors, verify credentials are added (all should have no access level, Untried status)
- [x] In another new workspace, import the second zip
- [x] Verify you get no errors, verify credentials are added (they should match the access level, status, and last attempted at as the original credentials, compare to that workspace)
- [x] In metasploit-credential dir, ```bundle install && rake spec```

## Post-merge Steps
Perform these steps prior to pushing to master or the build will be broken on master!

### Version
- [ ] Edit `lib/metasploit/credential/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

### Commit & Push
- [ ] `git commit -S -a`
- [ ] `git push origin master`

## Release
### MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_credential`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`