### PR TITLE
Build speed ups based around containerized builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
   - rake db:setup
+cache: bundler
 language: ruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
 cache: bundler
 language: ruby
 rvm:
-  - '1.9.3'
-  - '2.0'
-  - '2.1'
+  - 1.9.3
+  - 2.0
+  - 2.1
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ rvm:
   - '2.1'
   - 'jruby-19mode'
   - 'rbx-2.2'
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,8 @@ before_script:
   - rake db:setup
 cache: bundler
 language: ruby
-matrix:
-  allow_failures:
-    # Rubinius.mri_backtrace primitive failed (PrimitiveFailure)
-    - rvm: 'rbx-2.2'
 rvm:
   - '1.9.3'
   - '2.0'
   - '2.1'
-  - 'rbx-2.2'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,11 @@ cache: bundler
 language: ruby
 matrix:
   allow_failures:
-    # Validation failed: Data is not in the NTLMHash data format of
-    # <LAN Manager hex digest>:<NT LAN Manager hex digest>, where each hex digest is 32 lowercase hexadecimal
-    # characters.
-    - rvm: 'jruby-19mode'
     # Rubinius.mri_backtrace primitive failed (PrimitiveFailure)
     - rvm: 'rbx-2.2'
 rvm:
   - '1.9.3'
   - '2.0'
   - '2.1'
-  - 'jruby-19mode'
   - 'rbx-2.2'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
-  - rake db:setup
+  - bundle exec rake db:setup
 cache: bundler
 language: ruby
 rvm:

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
-#!/usr/bin/env rake
+require 'bundler/gem_tasks'
+
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,5 @@
 require 'bundler/gem_tasks'
-
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
+require 'bundler/setup'
 
 begin
   require 'rdoc/task'

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 6
+      PATCH = 7
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'containerize'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
MSP-11930

Turn on containerized builds using `sudo: false` for faster build startup.  Turn on bundle caching with `cache: bundler` for faster build install.  Remove `jruby-19mode` because it always fails.  Remove `rbx-2.2` because although it succeeds now, it takes longer so it delays build completion and since nothing else targets rbx, it eats up a job slot on our account on travis-ci, thereby slowing down our build queue.  Explitcly `bundle exec rake db:setup` for `cache: bundler` compatibility.

- [ ] Look at the [build log](https://travis-ci.org/rapid7/metasploit-credential/jobs/45555947)
- [ ] VERIFY containerized message in log: `This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.`
- [ ] VERIFY bundler cache in log: `adding /home/travis/build/rapid7/metasploit-credentialvendor/bundle to cache`

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/credential/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

- `PATCH` has already been incremented

## Rubygems

- No release to rubygems as this is a build infrastructure change only