### PR TITLE
migrate old creds to new creds again

### DIFF
--- a/db/migrate/20150106201450_old_creds_to_new_creds2.rb
+++ b/db/migrate/20150106201450_old_creds_to_new_creds2.rb
@@ -1,0 +1,9 @@
+# Implements a one-time migration of `Mdm::Cred` objects to
+# appropriate objects from {Metasploit::Credential}
+# This second run is due to the refactor of #report_auth_info
+# that means we should no longer be creating old creds anywhere.
+class OldCredsToNewCreds2 < ActiveRecord::Migration
+  def up
+    Metasploit::Credential::Migrator.new.migrate!
+  end
+end

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,8 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 8
+      PATCH = 9
+      PRERELEASE = 'report-auth-info'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,8 +7,7 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 9
-      PRERELEASE = 'report-auth-info'
+      PATCH = 10
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3669,6 +3669,8 @@ INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 
 INSERT INTO schema_migrations (version) VALUES ('20140922170030');
 
+INSERT INTO schema_migrations (version) VALUES ('20150106201450');
+
 INSERT INTO schema_migrations (version) VALUES ('21');
 
 INSERT INTO schema_migrations (version) VALUES ('22');


### PR DESCRIPTION
with framework updating report_auth_info we
should no longer be creating any old creds. We just
need another migration to clean up any old creds created
in the interim

MSP-11919

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on DESTINATION

## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`