### PR TITLE
Fix non-replayable hash description

### DIFF
--- a/app/models/metasploit/credential/nonreplayable_hash.rb
+++ b/app/models/metasploit/credential/nonreplayable_hash.rb
@@ -1,4 +1,4 @@
-# A {Metasploit::Credential::PasswordHash password hash} that can be replayed to authenticate to other services.
+# A {Metasploit::Credential::PasswordHash password hash} that cannot be replayed to authenticate to other services.
 # Contrast with {Metasploit::Credential::ReplayableHash}.  {#data} is any password hash, such as those recovered from
 # `/etc/passwd` or `/etc/shadow`.
 class Metasploit::Credential::NonreplayableHash < Metasploit::Credential::PasswordHash


### PR DESCRIPTION
MSP-11984

Missing `not` in class documentation leads to class documentation implying the hash **is** replayable.

1. rake yard
2. open doc/Metasploit/Credential/NonreplayableHash.html

Actual:
"A password hash that can be replayed to authenticate to other services." in Overview

Expected:
"A password hash that cannot be replayed to authenticate to other services." in Overview

# Verification Steps
- [x] `rake yard`
- [x] `open doc/Metasploit/Credential/NonreplayableHash.html`
- [x] VERIFY Overview text contains `A password hash that cannot be replayed to authenticate to other services.`