### PR TITLE
update gemspec for new MDM dep

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,7 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 11
+      PATCH = 12
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # patching inverse association in Mdm models.
   s.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
   # Various Metasploit::Credential records have associations to Mdm records
-  s.add_runtime_dependency 'metasploit_data_models', '~> 0.21.0'
+  s.add_runtime_dependency 'metasploit_data_models', '~> 0.22.1'
   # Metasploit::Model::Search
   s.add_runtime_dependency 'metasploit-model','~> 0.28.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3268,6 +3268,13 @@ CREATE INDEX index_refs_on_name ON refs USING btree (name);
 
 
 --
+-- Name: index_services_on_host_id_and_port_and_proto; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_services_on_host_id_and_port_and_proto ON services USING btree (host_id, port, proto);
+
+
+--
 -- Name: index_services_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3670,6 +3677,8 @@ INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 INSERT INTO schema_migrations (version) VALUES ('20140922170030');
 
 INSERT INTO schema_migrations (version) VALUES ('20150106201450');
+
+INSERT INTO schema_migrations (version) VALUES ('20150112203945');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
MDM has mvoed to a new major version and we
need to pull that in as a desp

MSP-11643

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [ ] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on DESTINATION

## `VERSION`

### Compatible changes

If your change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit/credential/version.rb).

### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment [`MINOR`](lib/metasploit/credential/version.rb) and reset [`PATCH`](lib/metasploit/credential/version.rb) to `0`.

- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update [`MINOR`](lib/metasploit/credential/version.rb) and [`PATCH`](lib/metasploit/credential/version.rb) and commit the changes.

## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`