### PR TITLE
match? helpers

### DIFF
--- a/app/models/metasploit/credential/core.rb
+++ b/app/models/metasploit/credential/core.rb
@@ -287,6 +287,20 @@ class Metasploit::Credential::Core < ActiveRecord::Base
   # Instance Methods
   #
 
+  # Whether the {#public}'s {Public#username username} matches `regex`
+  #
+  # @param regex [Regexp]
+  def public_match?(regex)
+    !!(self.public.present? && self.public.username.match(regex))
+  end
+
+  # Whether the {#private}'s {Private#data data} matches `regex`
+  #
+  # @param regex [Regexp]
+  def private_match?(regex)
+    !!(self.private.present? && self.private.data.match(regex))
+  end
+
   private
 
   # Validates that the direct {#workspace} is consistent with the `Mdm::Workspace` accessible through the {#origin}.

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 13
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 12
+      PATCH = 13
+
+      PRERELEASE = 'match-helpers'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/models/metasploit/credential/core_spec.rb
+++ b/spec/models/metasploit/credential/core_spec.rb
@@ -868,4 +868,84 @@ describe Metasploit::Credential::Core do
 
   end
 
+  context 'instance methods' do
+    let(:core) do
+      FactoryGirl.build(
+          :metasploit_credential_core,
+          private: FactoryGirl.build(:metasploit_credential_password, data: "password"),
+          public: FactoryGirl.build(:metasploit_credential_public, username: "administrator")
+      )
+    end
+
+    context 'with both public and private' do
+      context '#public_match?' do
+        specify do
+          expect(core.public_match?(/admin/)).to eq(true)
+        end
+        specify do
+          expect(core.public_match?(/user/)).to eq(false)
+        end
+      end
+
+      context '#private_match?' do
+        specify do
+          expect(core.private_match?(/password/)).to eq(true)
+        end
+        specify do
+          expect(core.private_match?(/qwerty123/)).to eq(false)
+        end
+      end
+    end
+
+    context 'with no public' do
+      before(:each) do
+        core.public = nil
+      end
+
+      context '#public_match?' do
+        specify do
+          expect(core.public_match?(/admin/)).to eq(false)
+        end
+      end
+
+      context '#private_match?' do
+        specify do
+          expect(core.private_match?(/password/)).to eq(true)
+        end
+        specify do
+          expect(core.private_match?(/qwerty123/)).to eq(false)
+        end
+      end
+
+    end
+
+    context 'with no private' do
+      before(:each) do
+        core.private = nil
+      end
+
+      context '#public_match?' do
+        specify do
+          expect(core.public_match?(/admin/)).to eq(true)
+        end
+        specify do
+          expect(core.public_match?(/user/)).to eq(false)
+        end
+      end
+
+      context '#private_match?' do
+        specify do
+          expect(core.private_match?(/password/)).to eq(false)
+        end
+        specify do
+          expect(core.private_match?(/qwerty123/)).to eq(false)
+        end
+      end
+
+
+    end
+
+
+  end
+
 end


### PR DESCRIPTION
Add helper methods for checking a `Core`'s `Private` and `Public` values against a regular expression without having to dig into each object.  See rapid7/metasploit-framework#4634.

# Verification
- [ ] green Travis

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/credential/version.rb`
- [ ] Remove `PRERELEASE` and its comment

## Gem build
- [ ] `gem build *.gemspec`
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on DESTINATION

## `VERSION`

- x PATCH has already been incremented on this branch (0.13.13)

## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`