### PR TITLE
bump mdm version to get service validations

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -5,10 +5,11 @@ module Metasploit
       # The major version number.
       MAJOR = 0
       # The minor version number, scoped to the {MAJOR} version number.
-      MINOR = 13
+      MINOR = 14
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 19
+      PATCH = 0
 
+      PRERELEASE = 'unique-services'
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
       #

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # patching inverse association in Mdm models.
   s.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
   # Various Metasploit::Credential records have associations to Mdm records
-  s.add_runtime_dependency 'metasploit_data_models', '~> 0.22.8'
+  s.add_runtime_dependency 'metasploit_data_models', '~> 0.23.0'
   # Metasploit::Model::Search
   s.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3268,6 +3268,13 @@ CREATE INDEX index_refs_on_name ON refs USING btree (name);
 
 
 --
+-- Name: index_services_on_host_id_and_port_and_proto; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_services_on_host_id_and_port_and_proto ON services USING btree (host_id, port, proto);
+
+
+--
 -- Name: index_services_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3674,6 +3681,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150106201450');
 INSERT INTO schema_migrations (version) VALUES ('20150112203945');
 
 INSERT INTO schema_migrations (version) VALUES ('20150205192745');
+
+INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
get newest version of MDM to have service uniqueness
validations.
structure.sql already updated

MSP-11643

# Verification Steps
- [x] LAND https://github.com/rapid7/metasploit_data_models/pull/98
- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [ ] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/credential/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on DESTINATION

## `VERSION`

### Compatible changes

If your change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit/credential/version.rb).

### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment [`MINOR`](lib/metasploit/credential/version.rb) and reset [`PATCH`](lib/metasploit/credential/version.rb) to `0`.

- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update [`MINOR`](lib/metasploit/credential/version.rb) and [`PATCH`](lib/metasploit/credential/version.rb) and commit the changes.

## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`