### PR TITLE
metasploit-credential - remove Rails 4 warnings

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -9,6 +9,9 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 0
 
+      # the prerelease identifier
+      PRERELEASE = 'MSP-12174-metasploit-credential-deprecation-warnings'
+
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
       #

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -11,8 +11,6 @@ Dummy::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1165,7 +1165,8 @@ CREATE TABLE notes (
     updated_at timestamp without time zone,
     critical boolean,
     seen boolean,
-    data text
+    data text,
+    vuln_id integer
 );
 
 
@@ -3261,6 +3262,13 @@ CREATE INDEX index_notes_on_ntype ON notes USING btree (ntype);
 
 
 --
+-- Name: index_notes_on_vuln_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_notes_on_vuln_id ON notes USING btree (vuln_id);
+
+
+--
 -- Name: index_refs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3681,6 +3689,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150106201450');
 INSERT INTO schema_migrations (version) VALUES ('20150112203945');
 
 INSERT INTO schema_migrations (version) VALUES ('20150205192745');
+
+INSERT INTO schema_migrations (version) VALUES ('20150209195939');
 
 INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 

--- a/spec/factories/metasploit/credential/cores.rb
+++ b/spec/factories/metasploit/credential/cores.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :metasploit_credential_core,
           class: Metasploit::Credential::Core do
-    ignore do
+    transient do
       origin_factory { generate :metasploit_credential_core_origin_factory }
       private_factory { generate :metasploit_credential_core_private_factory }
       realm_factory { generate :metasploit_credential_core_realm_factory }
@@ -34,25 +34,25 @@ FactoryGirl.define do
     }
 
     factory :metasploit_credential_core_import do
-      ignore do
+      transient do
         origin_factory :metasploit_credential_origin_import
       end
     end
 
     factory :metasploit_credential_core_manual do
-      ignore do
+      transient do
         origin_factory :metasploit_credential_origin_manual
       end
     end
 
     factory :metasploit_credential_core_service do
-      ignore do
+      transient do
         origin_factory :metasploit_credential_origin_service
       end
     end
 
     factory :metasploit_credential_core_session do
-      ignore do
+      transient do
         origin_factory :metasploit_credential_origin_session
       end
     end

--- a/spec/factories/metasploit/credential/logins.rb
+++ b/spec/factories/metasploit/credential/logins.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :metasploit_credential_login,
           class: Metasploit::Credential::Login do
-    ignore do
+    transient do
       host {
         FactoryGirl.build(
           :mdm_host, workspace: workspace

--- a/spec/factories/metasploit/credential/origin/services.rb
+++ b/spec/factories/metasploit/credential/origin/services.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :metasploit_credential_origin_service,
           class: Metasploit::Credential::Origin::Service do
-    ignore do
+    transient do
       module_type { generate :metasploit_credential_origin_service_module_type }
       reference_name { generate :metasploit_credential_origin_service_reference_name }
     end

--- a/spec/factories/metasploit/credential/password_hashes.rb
+++ b/spec/factories/metasploit/credential/password_hashes.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
           # uses its own data sequence to differentiate password hashes from other private data and #type is
           # automatically set by ActiveRecord because Metasploit::Credential::Password is an STI subclass.
           class: Metasploit::Credential::Password do
-    ignore do
+    transient do
       password_data { generate :metasploit_credential_password_data }
     end
 

--- a/spec/factories/metasploit/credential/publics.rb
+++ b/spec/factories/metasploit/credential/publics.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :metasploit_credential_public,
           class: Metasploit::Credential::Username do
-    ignore do
+    transient do
       public_factory { [
         :metasploit_credential_username,
         :metasploit_credential_blank_username

--- a/spec/factories/metasploit/credential/ssh_keys.rb
+++ b/spec/factories/metasploit/credential/ssh_keys.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :metasploit_credential_ssh_key,
           class: Metasploit::Credential::SSHKey do
-    ignore do
+    transient do
       key_type { generate :metasploit_credential_ssh_key_key_type }
       # key size tuned for speed.  DO NOT use for production, it is below current recommended key size of 2048
       key_size { 512 }
@@ -13,13 +13,13 @@ FactoryGirl.define do
     }
 
     factory :metasploit_credential_dsa_key do
-      ignore do
+      transient do
         key_type :DSA
       end
     end
 
     factory :metasploit_credential_rsa_key do
-      ignore do
+      transient do
         key_type :RSA
       end
     end


### PR DESCRIPTION
### Description
  
This PR eliminates the following warnings for Rails 4

* Fix whiny_nils warning
* Fix FactoryGirl #ignore warning

### Verification Steps

Rails 3

* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no spec failures

Rails 4

* [ ] switch to Rails 4 env
* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no whiny_nils deprecation warnings

  ```
  DEPRECATION WARNING: config.whiny_nils option is deprecated and no longer
  works. (called from block in <top (required)> at /Users/sgonzalez/Projects/rapid7-
  other/metasploit-model/spec/dummy/config/environments/test.rb:15)
  ```
* [ ] verify no FactoryGirl #ignore warnings

  ```
  DEPRECATION WARNING: `#ignore` is deprecated and will be removed in 5.0. Please use
  `#transient` instead. (called from block (2 levels) in <top (required)> at
  /Users/sgonzalez/rapid7/metasploit-credential/spec/factories/metasploit/credential/cores.rb:4)
  ```

### Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

### Version
* [ ] Edit `lib/metasploit-credential/version.rb`
* [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
* [ ] gem build *.gemspec
* [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
* [ ] `rake spec`
* [ ] VERIFY version examples pass without failures

### Commit & Push
* [ ] `git commit -a`
* [ ] `git push origin master`

## Release
### JRuby
* [ ] `rvm use jruby@metasploit-credential`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`

### MRI Ruby
* [ ] `rvm use ruby-2.1.5@metasploit-credential`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`
