### PR TITLE
Feature/msp 12244/postgres pass the hash

### DIFF
--- a/app/models/metasploit/credential/postgres_md5.rb
+++ b/app/models/metasploit/credential/postgres_md5.rb
@@ -1,0 +1,41 @@
+# A {Metasploit::Credential::PasswordHash password hash} that can be {Metasploit::Credential::ReplayableHash replayed}
+# to authenticate to PostgreSQL servers. It is composed of a hexadecimal string of 32 charachters prepended by the string
+# 'md5'
+class Metasploit::Credential::PostgresMD5 < Metasploit::Credential::ReplayableHash
+
+  DATA_REGEXP = /md5([a-f0-9]{32})/
+
+  #
+  # Callbacks
+  #
+
+  before_validation :normalize_data
+
+  #
+  # Validations
+  #
+
+  validate :data_format
+
+  private
+
+  # Normalizes {#data} by making it all lowercase so that the unique validation and index on
+  # ({Metasploit::Credential::Private#type}, {#data}) catches collision in a case-insensitive manner without the need
+  # to use case-insensitive comparisons.
+  def normalize_data
+    if data
+      self.data = data.downcase
+    end
+  end
+
+  def data_format
+    unless DATA_REGEXP.match(data)
+      errors.add(:data, 'is not in Postgres MD5 Hash format')
+    end
+  end
+
+  public
+
+  Metasploit::Concern.run(self)
+
+end

--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -396,6 +396,9 @@ module Metasploit
               when :ntlm_hash
                 private_object = Metasploit::Credential::NTLMHash.where(data: private_data).first_or_create
                 private_object.jtr_format = 'nt,lm'
+              when :postgres_md5
+                private_object = Metasploit::Credential::PostgresMD5.where(data: private_data).first_or_create
+                private_object.jtr_format = 'raw-md5,postgres'
               when :nonreplayable_hash
                 private_object = Metasploit::Credential::NonreplayableHash.where(data: private_data).first_or_create
                 if opts[:jtr_format].present?

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 14
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 0
+      PATCH = 1
+
+      PRERELEASE = 'postgres-pass-the-hash'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1165,7 +1165,8 @@ CREATE TABLE notes (
     updated_at timestamp without time zone,
     critical boolean,
     seen boolean,
-    data text
+    data text,
+    vuln_id integer
 );
 
 
@@ -3261,6 +3262,13 @@ CREATE INDEX index_notes_on_ntype ON notes USING btree (ntype);
 
 
 --
+-- Name: index_notes_on_vuln_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_notes_on_vuln_id ON notes USING btree (vuln_id);
+
+
+--
 -- Name: index_refs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3681,6 +3689,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150106201450');
 INSERT INTO schema_migrations (version) VALUES ('20150112203945');
 
 INSERT INTO schema_migrations (version) VALUES ('20150205192745');
+
+INSERT INTO schema_migrations (version) VALUES ('20150209195939');
 
 INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 

--- a/spec/factories/metasploit/credential/postgres_md5.rb
+++ b/spec/factories/metasploit/credential/postgres_md5.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  klass = Metasploit::Credential::PostgresMD5
+
+  factory :metasploit_credential_postgres_md5,
+          class: klass,
+            parent: :metasploit_credential_replayable_hash do
+          data {
+            "md5#{SecureRandom.hex(16)}"
+          }
+          end
+end

--- a/spec/models/metasploit/credential/postgres_md5_spec.rb
+++ b/spec/models/metasploit/credential/postgres_md5_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Metasploit::Credential::PostgresMD5 do
+  it_should_behave_like 'Metasploit::Concern.run'
+
+  it { should be_a Metasploit::Credential::ReplayableHash }
+
+  context 'CONSTANTS' do
+    context 'DATA_REGEXP' do
+      subject(:data_regexp) do
+        described_class::DATA_REGEXP
+      end
+
+      it 'is valid if the string is md5 and 32 hex chars' do
+        hash = "md5#{SecureRandom.hex(16)}"
+        expect(data_regexp).to match(hash)
+      end
+
+      it 'is not valid if it does not start with md5' do
+        expect(data_regexp).not_to match(SecureRandom.hex(16))
+      end
+
+      it 'is not valid for an invalid length' do
+        expect(data_regexp).not_to match(SecureRandom.hex(6))
+      end
+
+      it 'is not valid if it is not hex chars after the md5 tag' do
+        bogus = "md5#{SecureRandom.hex(15)}jk"
+        expect(data_regexp).not_to match(bogus)
+      end
+
+    end
+  end
+
+
+end

--- a/spec/models/metasploit/credential/postgres_md5_spec.rb
+++ b/spec/models/metasploit/credential/postgres_md5_spec.rb
@@ -32,5 +32,93 @@ describe Metasploit::Credential::PostgresMD5 do
     end
   end
 
+  context 'callbacks' do
+    context 'before_validation' do
+      context '#data' do
+        subject(:data) do
+          postgres_md5.data
+        end
+
+        let(:postgres_md5) do
+          FactoryGirl.build(
+            :metasploit_credential_postgres_md5,
+            data: given_data
+          )
+        end
+
+        before(:each) do
+          postgres_md5.valid?
+        end
+
+        context 'with nil' do
+          let(:given_data) do
+            nil
+          end
+
+          it { should be_nil }
+        end
+
+        context 'with upper case characters' do
+          let(:given_data) do
+            'ABCDEF1234567890'
+          end
+
+          it 'makes them lower case' do
+            expect(data).to eq(given_data.downcase)
+          end
+        end
+
+        context 'with all lower case characters' do
+          let(:given_data) do
+            'abcdef1234567890'
+          end
+
+          it 'does not change the case' do
+            expect(data).to eq(given_data)
+          end
+        end
+      end
+    end
+  end
+
+  context 'factories' do
+    context 'metasploit_credential_ntlm_hash' do
+      subject(:metasploit_credential_postgres_md5) do
+        FactoryGirl.build(:metasploit_credential_postgres_md5)
+      end
+
+      it { should be_valid }
+    end
+  end
+
+  context 'validations' do
+    context '#data_format' do
+      subject(:data_errors) do
+        postgres_md5.errors[:data]
+      end
+
+      let(:data) { "md5#{SecureRandom.hex(16)}" }
+
+      let(:postgres_md5) do
+        FactoryGirl.build(
+          :metasploit_credential_postgres_md5,
+          data: data
+        )
+      end
+
+      context 'with a valid postgres md5 hash' do
+        it 'should be valid' do
+          expect(postgres_md5).to be_valid
+        end
+      end
+
+      context 'with an invalid postgres md5 hash' do
+        let(:data) { "invalidstring" }
+        it 'should not be valid' do
+          expect(postgres_md5).to_not be_valid
+        end
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
This PR adds a new sub-type of the Replayablehash called PostgresMD5. These are MD5 hashes specifically formatted in Postgres' style . They can be cracked like any other hash and can be replayed through Pass-the-Hash attacks

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on DESTINATION

## `VERSION`

### Compatible changes

If your change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit/credential/version.rb).

### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment [`MINOR`](lib/metasploit/credential/version.rb) and reset [`PATCH`](lib/metasploit/credential/version.rb) to `0`.

- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update [`MINOR`](lib/metasploit/credential/version.rb) and [`PATCH`](lib/metasploit/credential/version.rb) and commit the changes.

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`