### PR TITLE
Update to metasploit-concern 0.4.0

### DIFF
--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -9,7 +9,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 14
       # The patch number, scoped to the {MAJOR} and {MINOR} version number.
-      PATCH = 4
+      PATCH = 5
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version number.
+      PRERELEASE = 'app-concerns-eager-load'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   # patching inverse association in Mdm models.
-  s.add_runtime_dependency 'metasploit-concern', '0.4.0.pre.app.pre.concerns.pre.eager.pre.load'
+  s.add_runtime_dependency 'metasploit-concern', '0.4.0'
   # Various Metasploit::Credential records have associations to Mdm records
-  s.add_runtime_dependency 'metasploit_data_models', '0.23.3.pre.app.pre.concerns.pre.eager.pre.load'
+  s.add_runtime_dependency 'metasploit_data_models', '0.24.0'
   # Metasploit::Model::Search
   s.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   # patching inverse association in Mdm models.
-  s.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
+  s.add_runtime_dependency 'metasploit-concern', '0.4.0.pre.app.pre.concerns.pre.eager.pre.load'
   # Various Metasploit::Credential records have associations to Mdm records
-  s.add_runtime_dependency 'metasploit_data_models', '~> 0.23.0'
+  s.add_runtime_dependency 'metasploit_data_models', '0.23.3.pre.app.pre.concerns.pre.eager.pre.load'
   # Metasploit::Model::Search
   s.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'


### PR DESCRIPTION
MSP-12550

Update to use metasploit-concern 0.4.0

# Pre-verification Steps
- [x] Merge https://github.com/rapid7/metasploit_data_models/pull/113

# Verification Steps

- [x] `rm Gemfile.lock`
- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## `VERSION`

### Compatible changes

If your change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit/credential/version.rb).

### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment [`MINOR`](lib/metasploit/credential/version.rb) and reset [`PATCH`](lib/metasploit/credential/version.rb) to `0`.

- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update [`MINOR`](lib/metasploit/credential/version.rb) and [`PATCH`](lib/metasploit/credential/version.rb) and commit the changes.

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`