### PR TITLE
Documented undocumented constants to fix build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,14 @@ Make your changes or however many commits you like, committing each with `git co
 
 ### Pre-Pull Request Testing
 
+#### Specs
 1. Run specs one last time before opening the Pull Request: `rake spec`
 2. Verify there was no failures.
+
+#### Documentation
+1. Generate yard documentation to ensure all new code is documented: `rake yard`
+2. Verify there were no `[warn]`ings.
+3. Verify there were no undocumented objects.
 
 ### Push
 
@@ -60,6 +66,11 @@ Push your branch to your fork on github: `git push TYPE/ISSUE/SUMMARY`
 ## `rake spec`
 - [ ] `rake spec`
 - [ ] VERIFY no failures
+
+## `rake yard`
+- [ ] `rake yard`
+- [ ] VERIFY no `[warn]`ings
+- [ ] VERIFY no undocumented objects
 ```
 
 You should also include at least one scenario to manually check the changes outside of specs.

--- a/app/models/metasploit/credential/postgres_md5.rb
+++ b/app/models/metasploit/credential/postgres_md5.rb
@@ -2,7 +2,11 @@
 # to authenticate to PostgreSQL servers. It is composed of a hexadecimal string of 32 charachters prepended by the string
 # 'md5'
 class Metasploit::Credential::PostgresMD5 < Metasploit::Credential::ReplayableHash
+  #
+  # CONSTANTS
+  #
 
+  # Valid format for {Metasploit::Credential::Private#data}
   DATA_REGEXP = /md5([a-f0-9]{32})/
 
   #

--- a/lib/metasploit/credential/importer/pwdump.rb
+++ b/lib/metasploit/credential/importer/pwdump.rb
@@ -25,6 +25,7 @@ class Metasploit::Credential::Importer::Pwdump
   # Matches lines that contain usernames and plaintext passwords
   PLAINTEXT_REGEX                   = /^[\s]*([\x21-\x7f]+)[\s]+([\x21-\x7f]+)?/n
 
+  # Matches lines taht contain MD5 hashes for PostgreSQL
   POSTGRES_REGEX                    = /^[\s]*([\x21-\x7f]+):md5([0-9a-f]{32})$/
 
   # Matches a line that we use to get information for creating {Mdm::Host} and {Mdm::Service} objects

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -13,7 +13,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'undocumented'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-12796

Documented undocumented constants to fix YARD failing build due not 100% documented.

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [ ] VERIFY no `[warn]`ings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

## `VERSION`

### Bug fixes

- Incremented [`PATCH`](lib/metasploit/credential/version.rb).

## Release to rubygems.org

## ruby-2.1
- [ ] `rvm use ruby-2.1@metasploit-credential`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`