### PR TITLE
Fix unresolved YARD links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,14 @@ Make your changes or however many commits you like, committing each with `git co
 
 ### Pre-Pull Request Testing
 
+#### Specs
 1. Run specs one last time before opening the Pull Request: `rake spec`
 2. Verify there was no failures.
+
+#### Documentation
+1. Generate yard documentation to ensure all new code is documented: `rake yard`
+2. Verify there were no `[warn]`ings.
+3. Verify there were no undocumented objects.
 
 ### Push
 
@@ -60,6 +66,11 @@ Push your branch to your fork on github: `git push TYPE/ISSUE/SUMMARY`
 ## `rake spec`
 - [ ] `rake spec`
 - [ ] VERIFY no failures
+
+## `rake yard`
+- [ ] `rake yard`
+- [ ] VERIFY no `[warn]`ings
+- [ ] VERIFY no undocumented objects
 ```
 
 You should also include at least one scenario to manually check the changes outside of specs.

--- a/app/models/metasploit/credential/core.rb
+++ b/app/models/metasploit/credential/core.rb
@@ -12,7 +12,7 @@ class Metasploit::Credential::Core < ActiveRecord::Base
   #
 
   # @!attribute tasks
-  #   The {Mdm::Task tasks} using this to track what tasks interacted with a given core.
+  #   The `Mdm::Task`s using this to track what tasks interacted with a given core.
   #
   #   @return [ActiveRecord::Relation<Mdm::Task>]
   has_and_belongs_to_many :tasks,

--- a/app/models/metasploit/credential/login.rb
+++ b/app/models/metasploit/credential/login.rb
@@ -9,7 +9,7 @@ class Metasploit::Credential::Login < ActiveRecord::Base
   #
   
   # @!attribute tasks
-  #   The {Mdm::Task tasks} using this to track what tasks interacted with a given core.
+  #   The `Mdm::Task`s using this to track what tasks interacted with a given core.
   #
   #   @return [ActiveRecord::Relation<Mdm::Task>]
   has_and_belongs_to_many :tasks,

--- a/app/models/metasploit/credential/postgres_md5.rb
+++ b/app/models/metasploit/credential/postgres_md5.rb
@@ -2,7 +2,11 @@
 # to authenticate to PostgreSQL servers. It is composed of a hexadecimal string of 32 charachters prepended by the string
 # 'md5'
 class Metasploit::Credential::PostgresMD5 < Metasploit::Credential::ReplayableHash
+  #
+  # CONSTANTS
+  #
 
+  # Valid format for {Metasploit::Credential::Private#data}
   DATA_REGEXP = /md5([a-f0-9]{32})/
 
   #

--- a/app/models/metasploit/credential/search/operator/type.rb
+++ b/app/models/metasploit/credential/search/operator/type.rb
@@ -1,6 +1,6 @@
 # Operator that searches a polymorphic `#type` attribute.  Search terms are restricted to set of `Class#name`s and
 # `Class#model_name.human` with the `Class#model_name.human` being translated to `Class#name` in the operation returned
-# by {#operate_on}.
+# by `#operate_on`.
 class Metasploit::Credential::Search::Operator::Type < Metasploit::Model::Search::Operator::Attribute
   #
   # Attributes
@@ -40,7 +40,7 @@ class Metasploit::Credential::Search::Operator::Type < Metasploit::Model::Search
     @class_names ||= []
   end
 
-  # Maps `Class.model_name.human` to `Class.name` for all {#classes}.
+  # Maps `Class.model_name.human` to `Class.name` for {#class_set}.
   #
   # @return [Hash{String => String}] Maps `Class.model_name.name`s to `Class.name`s so `Class.model_names.name` can be
   #   converted to `Class.name` for the in database search.

--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -1,6 +1,6 @@
 # Implements a set of "convenience methods" for creating credentials and related portions of the object graph.  Creates
 # {Metasploit::Credential::Core} objects and their attendant relationships as well as {Metasploit::Credential::Login}
-# objects and their attendant {Mdm::Host} and {Mdm::Service} objects.
+# objects and their attendant `Mdm::Host` and `Mdm::Service` objects.
 module Metasploit::Credential::Creation
 
   # Returns true if ActiveRecord has an active database connection, false otherwise.

--- a/lib/metasploit/credential/exporter/core.rb
+++ b/lib/metasploit/credential/exporter/core.rb
@@ -3,7 +3,7 @@
 # and `Mdm::Server` information is exported as well. Exported data can be optionally scoped to include only
 # a certain whitelist of database IDs.
 #
-# The {#export!} method creates a zip file on disk containing a CSV with the data.  If the {#workspace} contains
+# The {#export!} method creates a zip file on disk containing a CSV with the data.  If the `workspace` contains
 # {Metasploit::Credential::SSHKey} objects on the exported {Metasploit::Credential::Core} objects, the keys are
 # exported to files inside a subdirectory of the zip file.
 # @example Exporting all Cores
@@ -41,7 +41,7 @@ class Metasploit::Credential::Exporter::Core
   # The downcased and Symbolized name of the default object type to export
   DEFAULT_MODE  = LOGIN_MODE
 
-  # An argument to {Dir::mktmpdir}
+  # An argument to `Dir::mktmpdir`
   TEMP_ZIP_PATH_PREFIX = "metasploit-exports"
 
 
@@ -109,7 +109,7 @@ class Metasploit::Credential::Exporter::Core
   end
 
   # Returns a platform-agnostic filesystem path where the key data will be saved as a file
-  # @param line [Hash] the result of {#line_for_login} or #{line_for_core}
+  # @param line [Hash] the result of {#line_for_login} or {#line_for_core}
   # @return [String]
   def path_for_key(datum)
     core = datum.is_a?(Metasploit::Credential::Core) ? datum : datum.core

--- a/lib/metasploit/credential/importer/pwdump.rb
+++ b/lib/metasploit/credential/importer/pwdump.rb
@@ -1,8 +1,8 @@
 # Implements importation behavior for pwdump files exported by Metasploit as well as files from the John the Ripper
 # hash cracking suite: http://www.openwall.com/john/
 #
-# Please note that in the case of data exported from Metasploit, the dataset will contain information on the {Mdm::Host}
-# and {Mdm::Service} objects that are related to the credential.  This means that Metasploit exports will be limited to
+# Please note that in the case of data exported from Metasploit, the dataset will contain information on the `Mdm::Host`
+# and `Mdm::Service` objects that are related to the credential.  This means that Metasploit exports will be limited to
 # containing {Metasploit::Credential::Login} objects, which is the legacy behavior of this export prior to the creation
 # of this library.
 class Metasploit::Credential::Importer::Pwdump
@@ -28,7 +28,7 @@ class Metasploit::Credential::Importer::Pwdump
   # Matches lines taht contain MD5 hashes for PostgreSQL
   POSTGRES_REGEX                    = /^[\s]*([\x21-\x7f]+):md5([0-9a-f]{32})$/
 
-  # Matches a line that we use to get information for creating {Mdm::Host} and {Mdm::Service} objects
+  # Matches a line that we use to get information for creating `Mdm::Host` and `Mdm::Service` objects
   # TODO: change to use named groups from 1.9+
   SERVICE_COMMENT_REGEX             = /^#[\s]*([0-9.]+):([0-9]+)(\x2f(tcp|udp))?[\s]*(\x28([^\x29]*)\x29)?/n
 
@@ -71,7 +71,7 @@ class Metasploit::Credential::Importer::Pwdump
     end
   end
 
-  # Perform the import of the credential data, creating {Mdm::Host} and {Mdm::Service} objects as needed,
+  # Perform the import of the credential data, creating `Mdm::Host` and `Mdm::Service` objects as needed,
   # parsing out data by matching against regex constants that match the various kinds of valid lines found
   # in the file.  Ignore lines which match none of the REGEX constants.
   # @return [void]
@@ -160,7 +160,7 @@ class Metasploit::Credential::Importer::Pwdump
   end
 
   # Take an msfpwdump comment string and parse it into information necessary for
-  # creating {Mdm::Host} and {Mdm::Service} objects.
+  # creating `Mdm::Host` and `Mdm::Service` objects.
   # @param comment_string [String] a string starting with a '#' that conforms to {SERVICE_COMMENT_REGEX}
   # @return [Hash]
   def service_info_from_comment_string(comment_string)

--- a/lib/metasploit/credential/importer/pwdump.rb
+++ b/lib/metasploit/credential/importer/pwdump.rb
@@ -25,6 +25,7 @@ class Metasploit::Credential::Importer::Pwdump
   # Matches lines that contain usernames and plaintext passwords
   PLAINTEXT_REGEX                   = /^[\s]*([\x21-\x7f]+)[\s]+([\x21-\x7f]+)?/n
 
+  # Matches lines taht contain MD5 hashes for PostgreSQL
   POSTGRES_REGEX                    = /^[\s]*([\x21-\x7f]+):md5([0-9a-f]{32})$/
 
   # Matches a line that we use to get information for creating {Mdm::Host} and {Mdm::Service} objects

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -13,9 +13,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 1
+      PATCH = 2
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      PRERELEASE = 'undocumented'
+      PRERELEASE = 'unresolved-links'
 
       #
       # Module Methods

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -13,7 +13,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'undocumented'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-12707

# Pre-verification Steps
- [x] Merge #108 

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no `[warn]`ings about unresolved links
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/credential/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

## `VERSION`

### Bug fixes

- Incremented [`PATCH`](lib/metasploit/credential/version.rb).

## Release to rubygems.org

## ruby-2.1
- [ ] `rvm use ruby-2.1@metasploit-credential`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`