### PR TITLE
Bug/msp 13025/creds csv import

### DIFF
--- a/lib/metasploit/credential/importer/core.rb
+++ b/lib/metasploit/credential/importer/core.rb
@@ -232,7 +232,6 @@ class Metasploit::Credential::Importer::Core
 
 
     end
-    puts all_creds_valid
     return  all_creds_valid
   end
 

--- a/lib/metasploit/credential/importer/multi.rb
+++ b/lib/metasploit/credential/importer/multi.rb
@@ -41,11 +41,11 @@ class Metasploit::Credential::Importer::Multi
     end
   end
 
-  # Perform the import
+  # Perform the import. Return true if import succeeded. Return false if any cred failed due to formatting.
   #
-  # @return [void]
+  # @return [Boolean]
   def import!
-    selected_importer.import!
+    return selected_importer.import!
   end
 
 

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -14,7 +14,7 @@ module Metasploit
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 1
-      PRERELEASE = 'creds_csv_import'
+      PRERELEASE = 'creds-csv-import'
 
       #
       # Module Methods

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -14,6 +14,7 @@ module Metasploit
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
       PATCH = 1
+      # The prerelease tag, to be removed before pushing a merged master.
       PRERELEASE = 'creds-csv-import'
 
       #

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -13,7 +13,8 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
+      PRERELEASE = 'creds_csv_import'
 
       #
       # Module Methods

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -2006,7 +2006,9 @@ CREATE TABLE vulns (
     info character varying(65536),
     exploited_at timestamp without time zone,
     vuln_detail_count integer DEFAULT 0,
-    vuln_attempt_count integer DEFAULT 0
+    vuln_attempt_count integer DEFAULT 0,
+    origin_id integer,
+    origin_type character varying(255)
 );
 
 
@@ -3663,6 +3665,13 @@ CREATE INDEX index_vulns_on_name ON vulns USING btree (name);
 
 
 --
+-- Name: index_vulns_on_origin_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_vulns_on_origin_id ON vulns USING btree (origin_id);
+
+
+--
 -- Name: index_web_forms_on_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -4064,6 +4073,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150317145455');
 INSERT INTO schema_migrations (version) VALUES ('20150326183742');
 
 INSERT INTO schema_migrations (version) VALUES ('20150421211719');
+
+INSERT INTO schema_migrations (version) VALUES ('20150514182921');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] VERIFY no failures

## `rake yard`
- [ ] `rake yard`
- [ ] VERIFY no `[warn]`ings
- [ ] VERIFY no undocumented objects

## Manual testing steps.
- [ ] point your 'pro' repo gemfile at your local metasploit-credential repo.
- [ ] Download the "minimal-cred-dump.csv" from the attachments section of the Jira story for this bug.
- [ ] Be sure you have the topic branch for this bug pulled on your pro repo
- [ ] attempt to import the CSV you downloaded on the creds management screen, with "NTLM Hash" selected in the dropdown.
- [ ] verify that you see an error message that one or more of the creds were invalid.
- [ ] land the pro pr
- [ ] merge this pr into metasploit-credential master on your own machine.
- [ ] then perform post-merge steps below.

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/credential/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`