### PR TITLE
revert changes from MSP-12512

### DIFF
--- a/app/models/metasploit/credential/core.rb
+++ b/app/models/metasploit/credential/core.rb
@@ -291,8 +291,8 @@ class Metasploit::Credential::Core < ActiveRecord::Base
     right.offset = nil
 
     Arel::Nodes::Union.new(
-      left,
-      right
+      origin_service_host_id(host_id).ast,
+      origin_session_host_id(host_id).ast
     ).to_sql
   end
 


### PR DESCRIPTION
# Verification Steps
- [ ]  in pro, be on ````bug/MS-906/remove-manual-removeal-of-order-statement``` (this branch won't get landed on pro... It's just a custom Gemfile that will pull in the code necessary to test this fix.)
- [ ] Get a session on windows host ````brute-w28s21-07.ms.scanlab.rapid7.com````
(use the ````exploit/windows/smb/psexec```` exploit with opts SMBUser: msfabd and
SMBPass: msfabd1)
- [ ] then navigate to that host’s page and click on the credential’s tab
- [ ] verify that credentials page renders properly.