### PR TITLE
set my deps free!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'coveralls', require: false
   # supplies factories for producing model instance for specs
   # Version 4.1.0 or newer is needed to support generate calls without the 'FactoryGirl.' in factory definitions syntax.
-  gem 'factory_girl', '>= 4.1.0'
+  gem 'factory_girl'
   # auto-load factories from spec/factories
   gem 'factory_girl_rails'
   # jquery-rails is used by the dummy application
@@ -48,9 +48,9 @@ group :development, :test do
   # code coverage of tests
   gem 'simplecov', :require => false
   # dummy app
-  gem 'rails', '>= 4.1', '< 4.2'
+  gem 'rails', '~> 4.1.15'
   # running documentation generation tasks and rspec tasks
-  gem 'rake', '~> 10.5'
+  gem 'rake'
   # unit testing framework with rails integration
-  gem 'rspec-rails', '~> 3.1'
+  gem 'rspec-rails'
 end

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   # Metasploit::Credential::NTLMHash helper methods
   s.add_runtime_dependency 'rubyntlm'
   # Required for supporting the en masse importation of SSH Keys
-  s.add_runtime_dependency 'rubyzip', '~> 1.1'
+  s.add_runtime_dependency 'rubyzip'
 
   if RUBY_PLATFORM =~ /java/
     s.add_runtime_dependency 'jdbc-postgres'


### PR DESCRIPTION
remove version locks wherever possible on gem
dependencies for rails 4.1 support

MS-1330

VERIFICATION STEPS
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY all specs pass