### PR TITLE
Create credential and login

### DIFF
--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -174,7 +174,7 @@ module Metasploit::Credential::Creation
   # @return [NilClass] if there is no active database connection
   # @return [Metasploit::Credential::Core]
   # @example Reporting a Bruteforced Credential and Login
-  #     create_credential(
+  #     create_credential_and_login(
   #       origin_type: :service,
   #       address: '192.168.1.100',
   #       port: 445,

--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -147,6 +147,8 @@ module Metasploit::Credential::Creation
   # which ties a {Metasploit::Credential::Core} to the `Mdm::Service` it is a valid
   # credential for.
   #
+  # NOTE: for origin_type: service it must be the same service your going to create a login for.
+  #
   # {Metasploit::Credential::Core} options
   # @option opts [String] :jtr_format The format for John the ripper to use to try and crack this
   # @option opts [Symbol] :origin_type The Origin type we are trying to create

--- a/spec/lib/metasploit/credential/creation_spec.rb
+++ b/spec/lib/metasploit/credential/creation_spec.rb
@@ -186,7 +186,6 @@ RSpec.describe Metasploit::Credential::Creation do
       session: Metasploit::Credential::Origin::Session
     }.each_pair do |origin_type, origin_class|
       context "Origin[#{origin_type}], Public[Username], Private[Password]" do
-        let(:service) { FactoryGirl.create(:mdm_service) }
         let!(:origin_data) {{
           cracked_password: {
             originating_core_id: FactoryGirl.create(

--- a/spec/lib/metasploit/credential/creation_spec.rb
+++ b/spec/lib/metasploit/credential/creation_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metasploit::Credential::Creation do
           import: {
             filename: FactoryGirl.generate(:metasploit_credential_origin_import_filename)
           },
-          manual: {},
+          manual: {user_id: user.id},
           service: {
             module_fullname: "exploit/" + FactoryGirl.generate(:metasploit_credential_origin_service_reference_name),
             address: service.host.address,
@@ -52,7 +52,6 @@ RSpec.describe Metasploit::Credential::Creation do
         }}
         let(:credential_data) {{
           workspace_id: workspace.id,
-          user_id: user.id,
           origin_type: origin_type,
           username: 'admin',
           private_data: 'password',
@@ -196,7 +195,7 @@ RSpec.describe Metasploit::Credential::Creation do
           import: {
             filename: FactoryGirl.generate(:metasploit_credential_origin_import_filename)
           },
-          manual: {},
+          manual: {user_id: user.id},
           service: {
             module_fullname: "exploit/" + FactoryGirl.generate(:metasploit_credential_origin_service_reference_name),
             address: service.host.address,
@@ -211,7 +210,6 @@ RSpec.describe Metasploit::Credential::Creation do
         }}
         let(:login_data) {{
           workspace_id: workspace.id,
-          user_id: user.id,
           origin_type: origin_type,
           username: 'admin',
           private_data: 'password',


### PR DESCRIPTION
We often create a login immediately after creating a credential. I'm rolling the two steps into a single method call. 

### Verification steps
open a rails console in ```spec/dummy```
```
workspace = FactoryGirl.create(:mdm_workspace)
user = FactoryGirl.create(:mdm_user)
service = FactoryGirl.create(:mdm_service, host: FactoryGirl.create(:mdm_host, workspace: workspace))

login_data = {
  workspace_id: workspace.id,
  origin_type: :manual,
  user_id: user.id,
  username: 'admin',
  private_data: 'password',
  private_type: :password,
  workspace_id: workspace.id,
  address: service.host.address,
  port: service.port,
  service_name: service.name,
  protocol: service.proto,
  last_attempted_at: DateTime.current,
  status: Metasploit::Model::Login::Status::SUCCESSFUL,
}
test_object = Class.new do
  include Metasploit::Credential::Creation
end.new

test_object.create_credential_and_login(login_data)
```
that should create the following objects
```
core = Metasploit::Credential::Core.last
core.public.username == 'admin'
core.private.data == 'password'
core.logins.first.status == 'Successful'
core.logins.first.service == service
```