### PR TITLE
Fix the bug on skipping entries.

### DIFF
--- a/lib/metasploit/credential/importer/core.rb
+++ b/lib/metasploit/credential/importer/core.rb
@@ -224,7 +224,7 @@ class Metasploit::Credential::Importer::Core
       end
       if all_creds_valid
         core_opts.each do |item|
-          if Metasploit::Credential::Core.where(private:item[:private]).blank?
+          if Metasploit::Credential::Core.where(public:item[:public],private:item[:private]).blank?
             create_credential_core(item)
           end
         end

--- a/lib/metasploit/credential/importer/core.rb
+++ b/lib/metasploit/credential/importer/core.rb
@@ -224,7 +224,7 @@ class Metasploit::Credential::Importer::Core
       end
       if all_creds_valid
         core_opts.each do |item|
-          if Metasploit::Credential::Core.where(public:item[:public],private:item[:private]).blank?
+          if Metasploit::Credential::Core.where(public: item[:public], private: item[:private]).blank?
             create_credential_core(item)
           end
         end


### PR DESCRIPTION
Currently an a new entry will be skipped just because its password appeared before, fixed it so that the entry will be skipped only
when the username and password pair appeared before.

Verify:
import a csv where there are some rows whose password fields are equal but username part are different and observe that they all show up (i.e. not will be skipped).