### PR TITLE
allow creation of a login against existing service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-credential (3.0.3)
+    metasploit-credential (3.0.4)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 3.0.0)
@@ -50,8 +50,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.4)
-    arel-helpers (2.8.0)
-      activerecord (>= 3.1.0, < 6)
+    arel-helpers (2.10.0)
+      activerecord (>= 3.1.0, < 7)
     bcrypt (3.1.12)
     builder (3.2.3)
     choice (0.2.0)
@@ -93,7 +93,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit_data_models (3.0.5)
+    metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
@@ -106,7 +106,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    net-ssh (5.1.0)
+    net-ssh (5.2.0)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pg (0.20.0)
@@ -148,11 +148,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
-    recog (2.1.45)
+    recog (2.3.6)
       nokogiri
     redcarpet (3.4.0)
     rex-core (0.1.13)
-    rex-socket (0.1.15)
+    rex-socket (0.1.21)
       rex-core
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
@@ -173,7 +173,7 @@ GEM
     rspec-support (3.8.0)
     ruby-graphviz (1.2.4)
     rubyntlm (0.6.2)
-    rubyzip (1.2.2)
+    rubyzip (2.0.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)

--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -276,6 +276,7 @@ module Metasploit::Credential::Creation
   # @option opts [DateTime] :last_attempted_at The last time this Login was attempted
   # @option opts [Metasploit::Credential::Core] :core The {Metasploit::Credential::Core} to link this login to
   # @option opts [Fixnum] :port The port number of the `Mdm::Service` to link this Login to
+  # @option opts [String] :service_id The ID of an `Mdm::Service` to link this login to
   # @option opts [String] :service_name The service name to use for the `Mdm::Service`
   # @option opts [String] :status The status for the Login object
   # @option opts [String] :protocol The protocol type of the `Mdm::Service` to link this Login to
@@ -298,7 +299,8 @@ module Metasploit::Credential::Creation
 
     login_object = nil
     retry_transaction do
-      service_object = create_credential_service(opts)
+      service_object = Mdm::Service.where(id: opts[:service_id]).first if opts[:service_id]
+      service_object = create_credential_service(opts) if service_object.nil?
       return nil if service_object.nil?
       login_object = Metasploit::Credential::Login.where(core_id: core.id, service_id: service_object.id).first_or_initialize
 


### PR DESCRIPTION
When creating a login object allow the `service_id` to be passed in lieu of all options required to be able to create the service from scratch.


This also picks up latest `Gemfile.lock` updates.