### PR TITLE
set default value for :address

### DIFF
--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -550,7 +550,7 @@ module Metasploit::Credential::Creation
   # @return [Mdm::Service]
   def create_credential_service(opts={})
     return nil unless active_db?
-    address          = opts.fetch(:address)
+    address          = opts.fetch(:address, nil)
     return nil unless Rex::Socket.is_ipv4?(address) || Rex::Socket.is_ipv6?(address)
     port             = opts.fetch(:port)
     service_name     = opts.fetch(:service_name)


### PR DESCRIPTION
#141 Explains an issue with a key error causing metasploit to prematurely error out during windows password cracking.  This PR ensures that the `:address` option has a default value defined to avoid an error condition.  The below screenshots show the difference with and without this fix in place.

**Module Options:**
![image](https://user-images.githubusercontent.com/16767909/72212764-56d92980-3497-11ea-9fd8-74d99af3a0df.png)

**Without Fix:**
![image](https://user-images.githubusercontent.com/16767909/72212767-82f4aa80-3497-11ea-8b81-6732f2c1bb46.png)

**With Fix:**
![image](https://user-images.githubusercontent.com/16767909/72212772-9f90e280-3497-11ea-989c-b30619f1aaf2.png)

As the screenshot above shows, implementing a default value for `:address` mitigates the error between scanning from a custom wordlist and moving on to the default wordlist.