### PR TITLE
Rails no longer delegates ast to Arel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-credential (4.0.0)
+    metasploit-credential (4.0.1)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 3.0.0)

--- a/app/models/metasploit/credential/core.rb
+++ b/app/models/metasploit/credential/core.rb
@@ -276,8 +276,8 @@ class Metasploit::Credential::Core < ApplicationRecord
   # @param host_id [Integer]
   # @return [String]
   def self.cores_from_host(host_id)
-    left = origin_service_host_id(host_id).ast
-    right = origin_session_host_id(host_id).ast
+    left = origin_service_host_id(host_id).arel.ast
+    right = origin_session_host_id(host_id).arel.ast
 
     Arel::Nodes::UnionAll.new(
       left,


### PR DESCRIPTION
Delegate directly to Arel to remove Rails 5 deprecation.
See: https://github.com/rails/rails/pull/29619