### PR TITLE
Address ActiveModel::Errors deprecation warning

### DIFF
--- a/app/models/metasploit/credential/ssh_key.rb
+++ b/app/models/metasploit/credential/ssh_key.rb
@@ -110,7 +110,7 @@ class Metasploit::Credential::SSHKey < Metasploit::Credential::Private
       begin
         openssl_pkey_pkey
       rescue ArgumentError, OpenSSL::PKey::PKeyError => error
-        errors[:data] << "#{error.class} #{error}"
+        errors.add(:data, "#{error.class} #{error}")
       end
     end
   end


### PR DESCRIPTION
Address this deprecation warning
```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from rescue in readable at /home/runner/work/metasploit-credential/metasploit-credential/app/models/metasploit/credential/ssh_key.rb:113)
```