### PR TITLE
update belongs_to relationships

### DIFF
--- a/app/models/metasploit/credential/core.rb
+++ b/app/models/metasploit/credential/core.rb
@@ -52,6 +52,7 @@ class Metasploit::Credential::Core < ApplicationRecord
   #   @return [Metasploit::Credential::Private, nil]
   belongs_to :private,
              class_name: 'Metasploit::Credential::Private',
+             optional: true,
              inverse_of: :cores
 
   # @!attribute public
@@ -60,6 +61,7 @@ class Metasploit::Credential::Core < ApplicationRecord
   #   @return [Metasploit::Credential::Public, nil]
   belongs_to :public,
              class_name: 'Metasploit::Credential::Public',
+             optional: true,
              inverse_of: :cores
 
   # @!attribute realm
@@ -69,6 +71,7 @@ class Metasploit::Credential::Core < ApplicationRecord
   #   @return [Metasploit::Credential::Realm, nil]
   belongs_to :realm,
              class_name: 'Metasploit::Credential::Realm',
+             optional: true,
              inverse_of: :cores
 
   # @!attribute workspace

--- a/app/models/metasploit/credential/core.rb
+++ b/app/models/metasploit/credential/core.rb
@@ -208,7 +208,7 @@ class Metasploit::Credential::Core < ApplicationRecord
   scope :originating_host_id, ->(host_id) {
     where(
       Metasploit::Credential::Core[:id].in(
-        Metasploit::Credential::Core.cores_from_host(host_id)
+        self.cores_from_host(host_id)
       )
     )
   }

--- a/app/models/metasploit/credential/origin/import.rb
+++ b/app/models/metasploit/credential/origin/import.rb
@@ -19,6 +19,7 @@ class Metasploit::Credential::Origin::Import < ApplicationRecord
   #   @return [Mdm::Task]
   belongs_to :task,
              class_name: 'Mdm::Task',
+             optional: true,
              inverse_of: :import_credential_origins
 
   #

--- a/spec/models/metasploit/credential/core_spec.rb
+++ b/spec/models/metasploit/credential/core_spec.rb
@@ -72,12 +72,9 @@ RSpec.describe Metasploit::Credential::Core, type: :model do
     it { is_expected.to have_and_belong_to_many(:tasks).class_name('Mdm::Task') }
     it { is_expected.to have_many(:logins).class_name('Metasploit::Credential::Login').dependent(:destroy) }
     it { is_expected.to belong_to(:origin) }
-    it { expect(described_class.reflect_on_association(:private).macro).to eq(:belongs_to) }
-    it { expect(described_class.reflect_on_association(:private).class_name).to eq('Metasploit::Credential::Private') }
-    it { expect(described_class.reflect_on_association(:public).macro).to eq(:belongs_to) }
-    it { expect(described_class.reflect_on_association(:public).class_name).to eq('Metasploit::Credential::Public') }
-    it { expect(described_class.reflect_on_association(:realm).macro).to eq(:belongs_to) }
-    it { expect(described_class.reflect_on_association(:realm).class_name).to eq('Metasploit::Credential::Realm') }
+    it { is_expected.to belong_to(:private).optional.class_name('Metasploit::Credential::Private') }
+    it { is_expected.to belong_to(:public).optional.class_name('Metasploit::Credential::Public') }
+    it { is_expected.to belong_to(:realm).optional.class_name('Metasploit::Credential::Realm') }
     it { is_expected.to belong_to(:workspace).class_name('Mdm::Workspace') }
   end
 

--- a/spec/models/metasploit/credential/core_spec.rb
+++ b/spec/models/metasploit/credential/core_spec.rb
@@ -72,9 +72,12 @@ RSpec.describe Metasploit::Credential::Core, type: :model do
     it { is_expected.to have_and_belong_to_many(:tasks).class_name('Mdm::Task') }
     it { is_expected.to have_many(:logins).class_name('Metasploit::Credential::Login').dependent(:destroy) }
     it { is_expected.to belong_to(:origin) }
-    it { is_expected.to belong_to(:private).class_name('Metasploit::Credential::Private') }
-    it { is_expected.to belong_to(:public).class_name('Metasploit::Credential::Public') }
-    it { is_expected.to belong_to(:realm).class_name('Metasploit::Credential::Realm') }
+    it { expect(described_class.reflect_on_association(:private).macro).to eq(:belongs_to) }
+    it { expect(described_class.reflect_on_association(:private).class_name).to eq('Metasploit::Credential::Private') }
+    it { expect(described_class.reflect_on_association(:public).macro).to eq(:belongs_to) }
+    it { expect(described_class.reflect_on_association(:public).class_name).to eq('Metasploit::Credential::Public') }
+    it { expect(described_class.reflect_on_association(:realm).macro).to eq(:belongs_to) }
+    it { expect(described_class.reflect_on_association(:realm).class_name).to eq('Metasploit::Credential::Realm') }
     it { is_expected.to belong_to(:workspace).class_name('Mdm::Workspace') }
   end
 

--- a/spec/models/metasploit/credential/origin/import_spec.rb
+++ b/spec/models/metasploit/credential/origin/import_spec.rb
@@ -3,8 +3,7 @@ RSpec.describe Metasploit::Credential::Origin::Import, type: :model do
 
   context 'associations' do
     it { is_expected.to have_many(:cores).class_name('Metasploit::Credential::Core').dependent(:destroy) }
-    it { expect(described_class.reflect_on_association(:task).macro).to eq(:belongs_to) }
-    it { expect(described_class.reflect_on_association(:task).class_name).to eq('Mdm::Task') }
+    it { is_expected.to belong_to(:task).optional.class_name('Mdm::Task') }
   end
 
   context 'database' do

--- a/spec/models/metasploit/credential/origin/import_spec.rb
+++ b/spec/models/metasploit/credential/origin/import_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe Metasploit::Credential::Origin::Import, type: :model do
 
   context 'associations' do
     it { is_expected.to have_many(:cores).class_name('Metasploit::Credential::Core').dependent(:destroy) }
-    it { is_expected.to belong_to(:task).class_name('Mdm::Task') }
+    it { expect(described_class.reflect_on_association(:task).macro).to eq(:belongs_to) }
+    it { expect(described_class.reflect_on_association(:task).class_name).to eq('Mdm::Task') }
   end
 
   context 'database' do


### PR DESCRIPTION
New default converts `belongs_to` validation to default
as `required`, models must now declare `optional` values.