### PR TITLE
when importing creds scope to workspace

### DIFF
--- a/lib/metasploit/credential/importer/core.rb
+++ b/lib/metasploit/credential/importer/core.rb
@@ -224,7 +224,7 @@ class Metasploit::Credential::Importer::Core
       end
       if all_creds_valid
         core_opts.each do |item|
-          if Metasploit::Credential::Core.where(public: item[:public], private: item[:private]).blank?
+          if Metasploit::Credential::Core.where(origin: item[:origin], workspace_id: item[:workspace_id], public: item[:public], private: item[:private]).blank?
             create_credential_core(item)
           end
         end


### PR DESCRIPTION
Credentials are workspace specific, if an existing value
is stored in another workspace it should still be imported.

# Verification
- [ ] Tests added to document change
