### PR TITLE
Add support for openssl3

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,21 @@
 name: Verify
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 on:
   push:
     branches:
@@ -10,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
 
     services:
@@ -34,6 +50,13 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+        os:
+          - ubuntu-18.04
+          - ubuntu-22.04
+        exclude:
+          - { os: ubuntu-22.04, ruby: 2.6 }
+          - { os: ubuntu-22.04, ruby: 2.7 }
+          - { os: ubuntu-22.04, ruby: 3.0 }
 
     env:
       RAILS_ENV: test

--- a/app/models/metasploit/credential/ntlm_hash.rb
+++ b/app/models/metasploit/credential/ntlm_hash.rb
@@ -1,5 +1,22 @@
 require 'net/ntlm'
 
+# TODO: Revert once available in rubyntlm
+# https://github.com/WinRb/rubyntlm/pull/51
+module Net
+  module NTLM
+    class << self
+      def apply_des(plain, keys)
+        keys.map {|k|
+          dec = OpenSSL::Cipher.new("des-cbc").encrypt
+          dec.padding = 0
+          dec.key = k
+          dec.update(plain) + dec.final
+        }
+      end
+    end
+  end
+end
+
 # A {Metasploit::Credential::PasswordHash password hash} that can be {Metasploit::Credential::ReplayableHash replayed}
 # to authenticate to SMB.  It is composed of two hash hex digests (where the hash bytes are printed as a
 # hexadecimal string where 2 characters represent a byte of the original hash with the high nibble first): (1)

--- a/spec/factories/metasploit/credential/ssh_keys.rb
+++ b/spec/factories/metasploit/credential/ssh_keys.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     transient do
       key_type { generate :metasploit_credential_ssh_key_key_type }
       # key size tuned for speed.  DO NOT use for production, it is below current recommended key size of 2048
-      key_size { 512 }
+      key_size { 1024 }
     end
 
     data {

--- a/spec/models/metasploit/credential/ssh_key_spec.rb
+++ b/spec/models/metasploit/credential/ssh_key_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metasploit::Credential::SSHKey, type: :model do
 
   let(:key_size) do
     # key size tuned for speed.  DO NOT use for production, it is below current recommended key size of 2048
-    512
+    1024
   end
 
   context 'factories' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+# Enable legacy providers
+ENV['OPENSSL_CONF'] = File.expand_path(
+  File.join(File.dirname(__FILE__), 'support', 'openssl.conf')
+)
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 

--- a/spec/support/openssl.conf
+++ b/spec/support/openssl.conf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1


### PR DESCRIPTION
Relates to https://github.com/rapid7/metasploit-framework/issues/16818

Updating this repository to support OpenSSL 3

## Verification

- Code review
- Verify CI passes