### PR TITLE
Add support for rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,13 @@
+
 source "https://rubygems.org"
 
 # Declare your gem's dependencies in metasploit-credential.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec
+
+gem 'metasploit-concern', git: 'https://github.com/jmartin-r7/metasploit-concern', branch: 'add-support-for-rails-7'
+gem 'metasploit_data_models', git: 'https://github.com/jmartin-r7/metasploit_data_models', branch: 'add-support-for-rails-7'
 
 group :development do
   # Entity-Relationship diagrams for developers that need to access database using SQL directly.

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,9 @@
-
 source "https://rubygems.org"
 
 # Declare your gem's dependencies in metasploit-credential.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec
-
-gem 'metasploit-concern', git: 'https://github.com/jmartin-r7/metasploit-concern', branch: 'add-support-for-rails-7'
-gem 'metasploit_data_models', git: 'https://github.com/jmartin-r7/metasploit_data_models', branch: 'add-support-for-rails-7'
 
 group :development do
   # Entity-Relationship diagrams for developers that need to access database using SQL directly.

--- a/doc/graffles/metasploit-credential.graffle
+++ b/doc/graffles/metasploit-credential.graffle
@@ -1313,7 +1313,7 @@
 
 \f0\b0\fs12 \cf0 belongs_to: Metasploit::Credential::Public\
 belongs_to: Metasploit::Credential::Private\
-belongs_to: Metasploit:Credential::Context\
+belongs_to: Metasploit:Credential::Realm\
 belongs_to: Metasploit::Credential::Login\
 belongs_to: Metasploit::Credential::Origin}</string>
 						<key>VerticalPad</key>
@@ -2191,7 +2191,7 @@ belongs_to: Metasploit::Credential::Origin}</string>
 {\colortbl;\red255\green255\blue255;}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\slleading40\qc
 
-\f0\b\fs24 \cf0 Metasploit::Credential::Context}</string>
+\f0\b\fs24 \cf0 Metasploit::Credential::Realm}</string>
 						<key>VerticalPad</key>
 						<integer>2</integer>
 					</dict>
@@ -2284,7 +2284,7 @@ belongs_to: Metasploit::Credential::Origin}</string>
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\slleading40
 
 \f0\fs18 \cf0 Model: 
-\f1\b Metasploit::Credential::Context
+\f1\b Metasploit::Credential::Realm
 \fs20 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\slleading40
 

--- a/lib/metasploit/credential/version.rb
+++ b/lib/metasploit/credential/version.rb
@@ -3,7 +3,7 @@
 module Metasploit
   module Credential
     # VERSION is managed by GemRelease
-    VERSION = '5.0.10'
+    VERSION = '6.0.0'
 
     # @return [String]
     #

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(/spec/)
   s.require_paths = %w{app/models app/validators lib}
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   # patching inverse association in Mdm models.
   s.add_runtime_dependency 'metasploit-concern'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -56,6 +56,8 @@ module Dummy
     config.active_record.schema_format = :sql
 
     config.autoloader = :zeitwerk
+
+    ActiveRecord.legacy_connection_handling = false
   end
 end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -57,7 +57,9 @@ module Dummy
 
     config.autoloader = :zeitwerk
 
-    ActiveRecord.legacy_connection_handling = false
+    if ActiveRecord.respond_to?(:legacy_connection_handling)
+      ActiveRecord.legacy_connection_handling = false
+    end
   end
 end
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -22,18 +22,6 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx


### PR DESCRIPTION
Updates to support Rails 7

* Remove configuration references to `assets` not used in the gem
* Updates test `ActiveRecord` connection handling to remove testing warning.
* Update entity diagram to reflect `Context` became `Realm`