### PR TITLE
Add kerberos encryption key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@
 /pkg/
 *.gem
 
+# https://github.com/rapid7/metasploit_data_models/blob/f2887d79c84452522493d1531d3f658ee6da9213/.gitignore#L14
+# Don't check in these files as this is a gem
+.rvmrc
+Gemfile.lock
+
 # simplecov
 /coverage
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem 'redcarpet'
   gem 'yard'
   gem 'e2mmap'
-
+  gem 'pry-byebug'
 end
 
 group :development, :test do

--- a/app/models/metasploit/credential/krb_enc_key.rb
+++ b/app/models/metasploit/credential/krb_enc_key.rb
@@ -1,0 +1,184 @@
+require 'json'
+
+# A {Metasploit::Credential::PasswordHash password hash} that cannot be replayed to authenticate to other services.
+# {#data} is a string in the format `'msf_krbenckey:<enctype digits>:<key hexadecimal>:<salt hexadecimal>'`.
+#
+# This class contains information relevant to a Kerberos EncryptionKey https://www.rfc-editor.org/rfc/rfc4120.html#section-5.2.9
+# which is used to encrypt/decrypt arbitrary Kerberos protocol message data - such as the AS-REP krbtgt ticket and enc-part.
+class Metasploit::Credential::KrbEncKey < Metasploit::Credential::PasswordHash
+
+  #
+  # Constants
+  #
+
+  # Valid format for KrbEncKey enctype portion of {#data}: numeric characters
+  # @see ENCTYPE_NAMES
+  TYPE_REGEXP = /(?<enctype>\d+)/
+  private_constant :TYPE_REGEXP
+
+  # Valid format for KrbEncKey key portion of {#data}: lowercase hexadecimal characters
+  KEY_REGEXP = /(?<key>[0-9a-f]+)/
+  private_constant :KEY_REGEXP
+
+  # Valid format for KrbEncKey enctype portion of {#data}: lowercase hexadecimal characters
+  SALT_REGEXP = /(?<salt>[0-9a-f]*)/
+  private_constant :SALT_REGEXP
+
+  # Valid format for {#data} composed of `'msf_krbenckey:<enctype digits>:<key hexadecimal>:<salt hexadecimal>'`.
+  DATA_REGEXP = /\Amsf_krbenckey:#{TYPE_REGEXP}:#{KEY_REGEXP}:#{SALT_REGEXP}\z/
+  private_constant :DATA_REGEXP
+
+  # https://www.iana.org/assignments/kerberos-parameters/kerberos-parameters.xhtml
+  ENCTYPE_NAMES = (Hash.new { |_hash, enctype| "unassigned-#{enctype}" }).merge({
+    0 => 'reserved-0',
+    1 => 'des-cbc-crc',
+    2 => 'des-cbc-md4',
+    3 => 'des-cbc-md5',
+    4 => 'reserved-4',
+    5 => 'des3-cbc-md5',
+    6 => 'reserved-6',
+    7 => 'des3-cbc-sha1',
+    8 => 'unassigned-8',
+    9 => 'dsaWithSHA1-CmsOID',
+    10 => 'md5WithRSAEncryption-CmsOID',
+    11 => 'sha1WithRSAEncryption-CmsOID',
+    12 => 'rc2CBC-EnvOID',
+    13 => 'rsaEncryption-EnvOID',
+    14 => 'rsaES-OAEP-ENV-OID',
+    15 => 'des-ede3-cbc-Env-OID',
+    16 => 'des3-cbc-sha1-kd',
+    17 => 'aes128-cts-hmac-sha1-96',
+    18 => 'aes256-cts-hmac-sha1-96',
+    19 => 'aes128-cts-hmac-sha256-128',
+    20 => 'aes256-cts-hmac-sha384-192',
+    21 => 'unassigned-21',
+    22 => 'unassigned-22',
+    23 => 'rc4-hmac',
+    24 => 'rc4-hmac-exp',
+    25 => 'camellia128-cts-cmac',
+    26 => 'camellia256-cts-cmac',
+    65 => 'subkey-keymaterial'
+  })
+  private_constant :ENCTYPE_NAMES
+
+  #
+  # Attributes
+  #
+
+  # @!attribute data
+  #
+  #   @return [Hash{Symbol => String}]
+
+  #
+  # Callbacks
+  #
+
+  before_validation :normalize_data
+
+  #
+  # Validations
+  #
+
+  validate :data_format
+
+  #
+  # Class methods
+  #
+
+  # @param [Integer] enctype The enctype
+  # @param [String] key The key bytes
+  # @param [String,nil] salt The salt
+  # @return [String]
+  # @raise [ArgumentError] if an option is invalid
+  def self.build_data(enctype:, key:, salt: nil)
+    raise ArgumentError('enctype must be numeric') unless enctype.is_a?(Numeric)
+    raise ArgumentError('key must be set') if key.nil?
+
+    "msf_krbenckey:#{enctype}:#{as_hex(key)}:#{as_hex(salt)}"
+  end
+
+  #
+  # Instance Methods
+  #
+
+  # The enctype as defined by https://www.iana.org/assignments/kerberos-parameters/kerberos-parameters.xhtml
+  #
+  # @return [Integer]
+  def enctype
+    parsed_data[:enctype]
+  end
+
+  # The key
+  #
+  # @return [String]
+  def key
+    parsed_data[:key]
+  end
+
+  # The salt used as part of creating the key. This is normally derived from the Kerberos principal name/Realm.
+  # For windows the following convention is used to create the salt:
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/7a7b081d-c0c6-46f4-acbf-a439664270b8
+  #
+  # This value can be nil if the salt is not known
+  # @return [String,nil] The key salt if available
+  def salt
+    parsed_data[:salt]
+  end
+
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def to_s
+    "#{ENCTYPE_NAMES[enctype]}:#{self.class.as_hex(key)}#{salt ? ":#{self.class.as_hex(salt)}" : ''}"
+  end
+
+  private
+
+  # Converts a buffer containing bytes to a String containing the hex representation of the bytes
+  #
+  # @param hash [String,nil] a buffer of bytes
+  # @return [String] a string where every 2 hexadecimal characters represents a byte in the original hash buffer
+  def self.as_hex(value)
+    value.to_s.unpack1('H*')
+  end
+
+  # Converts a buffer containing bytes to a String containing the hex representation of the bytes
+  #
+  # @param hash [String,nil] a buffer of bytes
+  # @return [String] a string where every 2 hexadecimal characters represents a byte in the original hash buffer
+  def self.as_bytes(value)
+    [value.to_s].pack('H*')
+  end
+
+  # @return [Hash] The parsed data with enctype, key, salt keys
+  def parsed_data
+    match = data.match(DATA_REGEXP)
+    return {} unless match
+
+    {
+      enctype: match[:enctype].to_i,
+      key: self.class.as_bytes(match[:key]),
+      salt: match[:salt].empty? ? nil : self.class.as_bytes(match[:salt])
+    }
+  end
+
+  # Normalizes {#data} by making it all lowercase so that the unique validation and index on
+  # ({Metasploit::Credential::Private#type}, {#data}) catches collision in a case-insensitive manner without the need
+  # to use case-insensitive comparisons.
+  def normalize_data
+    if data
+      self.data = data.downcase
+    end
+  end
+
+  # Validates that {#data} is in the expected data format
+  def data_format
+    unless DATA_REGEXP.match(data)
+      errors.add(:data, :format)
+    end
+  end
+
+  public
+
+  Metasploit::Concern.run(self)
+end

--- a/app/models/metasploit/credential/private.rb
+++ b/app/models/metasploit/credential/private.rb
@@ -73,6 +73,7 @@ class Metasploit::Credential::Private < ApplicationRecord
                 Metasploit::Credential::NTLMHash
                 Metasploit::Credential::Password
                 Metasploit::Credential::SSHKey
+                Metasploit::Credential::KrbEncKey
               }
 
   #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     models:
       metasploit/credential/ntlm_hash: "NTLM hash"
       metasploit/credential/ssh_key: "SSH key"
+      metasploit/credential/krb_enc_key: 'Krb enc key'
     errors:
       models:
         metasploit/credential/core:
@@ -78,6 +79,10 @@ en:
           attributes:
             data:
               format: "is not in the NTLMHash data format of <LAN Manager hex digest>:<NT LAN Manager hex digest>, where each hex digest is 32 lowercase hexadecimal characters."
+        metasploit/credential/krb_enc_key:
+          attributes:
+            data:
+              format: "is not in the KrbEncKey data format of 'msf_krbenckey:<ENCTYPE>:<KEY>:<SALT>', where the key and salt are in hexadecimal characters"
         metasploit/credential/ssh_key:
           attributes:
             data:

--- a/lib/metasploit/credential.rb
+++ b/lib/metasploit/credential.rb
@@ -35,6 +35,7 @@ module Metasploit
     autoload :EntityRelationshipDiagram
     autoload :Exporter
     autoload :Importer
+    autoload :KrbEncKey
     autoload :Login
     autoload :Migrator
     autoload :NonreplayableHash

--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -462,6 +462,7 @@ module Metasploit::Credential::Creation
   # @return [Metasploit::Credential::SSHKey] if the private_type was :ssh_key
   # @return [Metasploit::Credential::NTLMHash] if the private_type was :ntlm_hash
   # @return [Metasploit::Credential::NonreplayableHash] if the private_type was :nonreplayable_hash
+  # @return [Metasploit::Credential::KrbEncKey] if the private_type was :krb_enc_key
   def create_credential_private(opts={})
     return nil unless active_db?
     private_data = opts.fetch(:private_data)
@@ -478,6 +479,8 @@ module Metasploit::Credential::Creation
           private_object = Metasploit::Credential::Password.where(data: private_data).first_or_create
         when :ssh_key
           private_object = Metasploit::Credential::SSHKey.where(data: private_data).first_or_create
+        when :krb_enc_key
+          private_object = Metasploit::Credential::KrbEncKey.where(data: private_data).first_or_create
         when :ntlm_hash
           private_object = Metasploit::Credential::NTLMHash.where(data: private_data).first_or_create
           private_object.jtr_format = 'nt,lm'

--- a/spec/factories/metasploit/credential/cores.rb
+++ b/spec/factories/metasploit/credential/cores.rb
@@ -62,7 +62,8 @@ FactoryBot.define do
       :metasploit_credential_password,
       :metasploit_credential_nonreplayable_hash,
       :metasploit_credential_ntlm_hash,
-      :metasploit_credential_ssh_key
+      :metasploit_credential_ssh_key,
+      :metasploit_credential_krb_enc_key
   ]
   sequence :metasploit_credential_core_private_factory, metasploit_credential_core_private_factories.cycle
 

--- a/spec/factories/metasploit/credential/krb_enc_key.rb
+++ b/spec/factories/metasploit/credential/krb_enc_key.rb
@@ -1,0 +1,81 @@
+require 'openssl'
+
+FactoryBot.define do
+  klass = Metasploit::Credential::KrbEncKey
+
+  factory :metasploit_credential_krb_enc_key,
+          class: klass,
+          parent: :metasploit_credential_password_hash do
+
+    # By default - use the with_rc4 trait for performance reasons
+    with_rc4
+
+    trait :with_rc4 do
+      data { generate(:metasploit_credential_krb_enc_key_rc4) }
+    end
+
+    trait :with_aes128 do
+      data { generate(:metasploit_credential_krb_enc_key_aes128) }
+    end
+
+    trait :with_aes256 do
+      data { generate(:metasploit_credential_krb_enc_key_aes256) }
+    end
+  end
+
+  sequence :metasploit_credential_krb_enc_key_rc4 do |n|
+    salt = nil
+    password = "password#{n}"
+    unicode_password = password.encode('utf-16le')
+    key = OpenSSL::Digest.digest('MD4', unicode_password)
+    enctype = 23
+
+    klass.build_data(enctype: enctype, key: key, salt: salt)
+  end
+
+  sequence :metasploit_credential_krb_enc_key_aes128 do |n|
+    salt = "DOMAIN.LOCALUserAccount#{n}"
+    password = "password#{n}"
+    key = aes_cts_hmac_sha1_96('128-CBC', password, salt)
+    enctype = 17
+
+    klass.build_data(enctype: enctype, key: key, salt: salt)
+  end
+
+  sequence :metasploit_credential_krb_enc_key_aes256 do |n|
+    salt = "DOMAIN.LOCALUserAccount#{n}"
+    password = "password#{n}"
+    enctype = 18
+    key = aes_cts_hmac_sha1_96('256-CBC', password, salt)
+
+    klass.build_data(enctype: enctype, key: key, salt: salt)
+  end
+
+  # Encrypt using MIT Kerberos aesXXX-cts-hmac-sha1-96
+  # http://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html?highlight=des#enctype-compatibility
+  #
+  # @param algorithm [String] The AES algorithm to use (e.g. `128-CBC` or `256-CBC`)
+  # @param raw_secret [String] The data to encrypt
+  # @param salt [String] The salt used by the encryption algorithm
+  # @return [String, nil] The encrypted data
+  def aes_cts_hmac_sha1_96(algorithm, raw_secret, salt)
+    iterations = 4096
+    cipher = OpenSSL::Cipher::AES.new(algorithm)
+    key = OpenSSL::PKCS5.pbkdf2_hmac_sha1(raw_secret, salt, iterations, cipher.key_len)
+    plaintext = "kerberos\x7B\x9B\x5B\x2B\x93\x13\x2B\x93".b
+    result = ''.b
+    loop do
+      cipher.reset
+      cipher.encrypt
+      cipher.iv = "\x00".b * 16
+      cipher.key = key
+      ciphertext = cipher.update(plaintext)
+      result += ciphertext
+      break unless result.size < cipher.key_len
+
+      plaintext = ciphertext
+    end
+    result
+  end
+
+end

--- a/spec/lib/metasploit/credential/creation_spec.rb
+++ b/spec/lib/metasploit/credential/creation_spec.rb
@@ -811,6 +811,16 @@ RSpec.describe Metasploit::Credential::Creation do
         expect(test_object.create_credential_private(opts)).to be_kind_of Metasploit::Credential::BlankPassword
       end
     end
+
+    context 'when :private_type is krb_enc_key' do
+      it 'creates a Metasploit::Credential::KrbEncKey' do
+        opts = {
+          private_data: FactoryBot.generate(:metasploit_credential_krb_enc_key_aes256),
+          private_type: :krb_enc_key
+        }
+        expect{ test_object.create_credential_private(opts) }.to change{ Metasploit::Credential::KrbEncKey.count }.by(1)
+      end
+    end
   end
 
   context '#create_credential_core' do

--- a/spec/models/metasploit/credential/krb_enc_key_spec.rb
+++ b/spec/models/metasploit/credential/krb_enc_key_spec.rb
@@ -1,0 +1,151 @@
+RSpec.shared_examples_for 'a KrbEncKey' do |expected:|
+  describe '#enctype' do
+    it 'has an enctype' do
+      expect(subject.enctype).to eq(expected[:enctype])
+    end
+  end
+
+  describe '#key' do
+    it 'has a key' do
+      expect(subject.key.length).to eq(expected[:key_length])
+    end
+  end
+
+  describe '#salt' do
+    it 'has a salt' do
+      expect(subject.salt).to match(expected[:salt])
+    end
+  end
+
+  describe '#to_s' do
+    it 'has a human readable to_s' do
+      expect(subject.to_s).to match expected[:to_s]
+    end
+  end
+end
+
+RSpec.describe Metasploit::Credential::KrbEncKey, type: :model do
+  it_should_behave_like 'Metasploit::Concern.run'
+
+  it { is_expected.to be_a Metasploit::Credential::PasswordHash }
+
+  context 'factories' do
+    context 'metasploit_credential_krb_enc_key' do
+      subject(:metasploit_credential_krb_enc_key) do
+        FactoryBot.build(:metasploit_credential_krb_enc_key)
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    FactoryBot.factories[:metasploit_credential_krb_enc_key].defined_traits.each do |trait|
+      context "with #{trait}" do
+        subject(:metasploit_credential_krb_enc_key) do
+          FactoryBot.build(:metasploit_credential_krb_enc_key, trait.name)
+        end
+
+        it { is_expected.to be_valid }
+        it { expect(subject.data).to be_a(String) }
+      end
+    end
+  end
+
+  context 'when the krb enc key is rc4' do
+    subject :krb_enc_key_rc4 do
+      FactoryBot.build(:metasploit_credential_krb_enc_key, :with_rc4)
+    end
+
+    it_behaves_like 'a KrbEncKey',
+                    expected: {
+                      enctype: 23,
+                      key_length: 16,
+                      salt: nil,
+                      to_s: /rc4-hmac:\w{32}/
+                    }
+  end
+
+  context 'when the krb enc key is aes128' do
+    subject :krb_enc_key_aes256 do
+      FactoryBot.build(:metasploit_credential_krb_enc_key, :with_aes128)
+    end
+
+    it_behaves_like 'a KrbEncKey',
+                    expected: {
+                      enctype: 17,
+                      key_length: 16,
+                      salt: /DOMAIN.LOCALUserAccount\d+/,
+                      to_s: /aes128-cts-hmac-sha1-96:\w{32}/
+                    }
+  end
+
+  context 'when the krb enc key is aes128' do
+    subject :krb_enc_key_aes256 do
+      FactoryBot.build(:metasploit_credential_krb_enc_key, :with_aes256)
+    end
+
+    it_behaves_like 'a KrbEncKey',
+                    expected: {
+                      enctype: 18,
+                      key_length: 32,
+                      salt: /DOMAIN.LOCALUserAccount\d+/,
+                      to_s: /aes256-cts-hmac-sha1-96:\w{64}/
+                    }
+  end
+
+  context 'when the krb enc key is not a known enctype' do
+    subject :krb_enc_key_aes256 do
+      FactoryBot.build(:metasploit_credential_krb_enc_key, data: described_class.build_data(enctype: 1024, key: "abc"))
+    end
+
+    it_behaves_like 'a KrbEncKey',
+                    expected: {
+                      enctype: 1024,
+                      key_length: 3,
+                      salt: nil,
+                      to_s: 'unassigned-1024:616263'
+                    }
+  end
+
+  context 'validations' do
+    context '#data' do
+      subject(:data_errors) do
+        krb_enc_key.errors[:data]
+      end
+
+      #
+      # lets
+      #
+
+      let(:data) do
+        FactoryBot.generate(:metasploit_credential_krb_enc_key_aes256)
+      end
+
+      let(:krb_enc_key) do
+        FactoryBot.build(
+          :metasploit_credential_krb_enc_key,
+          data: data
+        )
+      end
+
+      #
+      # Callbacks
+      #
+
+      before(:example) do
+        krb_enc_key.valid?
+      end
+
+      context 'when the data is valid' do
+        it { is_expected.to be_empty }
+      end
+
+      context "when the data is invalid" do
+        let(:data) do
+          "foo"
+        end
+
+        it { is_expected.to include("is not in the KrbEncKey data format of 'msf_krbenckey:<ENCTYPE>:<KEY>:<SALT>', where the key and salt are in hexadecimal characters") }
+      end
+    end
+  end
+end

--- a/spec/models/metasploit/credential/private_spec.rb
+++ b/spec/models/metasploit/credential/private_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe Metasploit::Credential::Private, type: :model do
                               Metasploit::Credential::NTLMHash
                               Metasploit::Credential::Password
                               Metasploit::Credential::SSHKey
+                              Metasploit::Credential::KrbEncKey
                             }
     end
   end


### PR DESCRIPTION
Alternative implementation of https://github.com/rapid7/metasploit-credential/pull/165

This PR adds a new Kerberos encryption key datamodel

Corresponding framework PR: https://github.com/rapid7/metasploit-framework/pull/17344