### PR TITLE
Update Ruby versions to be strings in verify.yml to prevent casting issues

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,15 +46,15 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.7'
+          - '3.0'
+          - '3.1'
         os:
           - ubuntu-20.04
           - ubuntu-latest
         exclude:
-          - { os: ubuntu-latest, ruby: 2.7 }
-          - { os: ubuntu-latest, ruby: 3.0 }
+          - { os: ubuntu-latest, ruby: '2.7' }
+          - { os: ubuntu-latest, ruby: '3.0' }
 
     env:
       RAILS_ENV: test
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
 
       - name: Test


### PR DESCRIPTION
Continuation of previous fixes for making sure all Ruby version strings in YAML are appropriately quoted to make sure we don't run into issues like https://github.com/rapid7/metasploit-framework/pull/17419.