### PR TITLE
Update the module name regex

### DIFF
--- a/app/models/metasploit/credential/origin/service.rb
+++ b/app/models/metasploit/credential/origin/service.rb
@@ -9,9 +9,9 @@ class Metasploit::Credential::Origin::Service < ApplicationRecord
   #
 
   # Regular expression that matches any `Mdm::Module::Detail#fullname` for {#module_full_name} where
-  # `Mdm::Module::Detail#mtype` is `'auxiliary'` or `'exploit'` and the remainder is a valid
+  # `Mdm::Module::Detail#mtype` is the module type, e.g. `'auxiliary'` or `'exploit'`, and the remainder is a valid
   # `Mdm::Module::Detail#refname` (it does not contain a `'\'` and is lower case alphanumeric).
-  MODULE_FULL_NAME_REGEXP = /\A(?<module_type>auxiliary|exploit|post)\/(?<reference_name>[\-0-9A-Z_a-z]+(?:\/[\-0-9A-Z_a-z]+)*)\Z/
+  MODULE_FULL_NAME_REGEXP = /\A(?<module_type>auxiliary|evasion|exploit|payload|post)\/(?<reference_name>[\-0-9A-Z_a-z]+(?:\/[\-0-9A-Z_a-z]+)*)\Z/
 
   #
   # Associations

--- a/spec/models/metasploit/credential/origin/service_spec.rb
+++ b/spec/models/metasploit/credential/origin/service_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe Metasploit::Credential::Origin::Service, type: :model do
             end
           end
 
+          context 'with evasion' do
+            let(:module_type) do
+              'evasion'
+            end
+
+            it 'allows value' do
+              expect(service_origin).to allow_value(module_full_name).for(:module_full_name)
+            end
+          end
+
           context 'with exploit' do
             let(:module_type) do
               'exploit'
@@ -108,7 +118,7 @@ RSpec.describe Metasploit::Credential::Origin::Service, type: :model do
             end
 
             it 'allows value' do
-              expect(service_origin).not_to allow_value(module_full_name).for(:module_full_name)
+              expect(service_origin).to allow_value(module_full_name).for(:module_full_name)
             end
           end
 


### PR DESCRIPTION
The module name regex only includes a subset of modules types that Metasploit supports. This notably prevents modules which create handlers such as payloads and evasion modules from storing information in the database.