### PR TITLE
Fix rails 7.2 warnings

### DIFF
--- a/app/models/metasploit/credential/krb_enc_key.rb
+++ b/app/models/metasploit/credential/krb_enc_key.rb
@@ -73,7 +73,7 @@ class Metasploit::Credential::KrbEncKey < Metasploit::Credential::PasswordHash
   # Callbacks
   #
 
-  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
   validates_uniqueness_of :data, :case_sensitive => false
 
   #

--- a/app/models/metasploit/credential/ntlm_hash.rb
+++ b/app/models/metasploit/credential/ntlm_hash.rb
@@ -60,7 +60,7 @@ class Metasploit::Credential::NTLMHash < Metasploit::Credential::ReplayableHash
 
   # Hash results are always downcased when stored in the database
   # This serializer allows for ORM to search in a case-insensitive
-  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
 
   #
   # Validations

--- a/app/models/metasploit/credential/postgres_md5.rb
+++ b/app/models/metasploit/credential/postgres_md5.rb
@@ -13,7 +13,7 @@ class Metasploit::Credential::PostgresMD5 < Metasploit::Credential::ReplayableHa
   # Callbacks
   #
 
-  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
   validates_uniqueness_of :data, :case_sensitive => false
 
   #


### PR DESCRIPTION
`metasploit-credential` does not have a `Gemfile.lock` so a fresh checkout will install Rails 7.2 - which generates multiple warnings. This pull request updates the repository to work with Rails 7.2