### PR TITLE
Pin tests to Rails 7.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   # code coverage of tests
   gem 'simplecov', :require => false
   # dummy app
-  gem 'rails'
+  gem 'rails', '7.0.8'
   # running documentation generation tasks and rspec tasks
   gem 'rake'
   # unit testing framework with rails integration

--- a/app/models/metasploit/credential/krb_enc_key.rb
+++ b/app/models/metasploit/credential/krb_enc_key.rb
@@ -73,7 +73,7 @@ class Metasploit::Credential::KrbEncKey < Metasploit::Credential::PasswordHash
   # Callbacks
   #
 
-  serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
+  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
   validates_uniqueness_of :data, :case_sensitive => false
 
   #

--- a/app/models/metasploit/credential/ntlm_hash.rb
+++ b/app/models/metasploit/credential/ntlm_hash.rb
@@ -60,7 +60,7 @@ class Metasploit::Credential::NTLMHash < Metasploit::Credential::ReplayableHash
 
   # Hash results are always downcased when stored in the database
   # This serializer allows for ORM to search in a case-insensitive
-  serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
+  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
 
   #
   # Validations

--- a/app/models/metasploit/credential/postgres_md5.rb
+++ b/app/models/metasploit/credential/postgres_md5.rb
@@ -13,7 +13,7 @@ class Metasploit::Credential::PostgresMD5 < Metasploit::Credential::ReplayableHa
   # Callbacks
   #
 
-  serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
+  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
   validates_uniqueness_of :data, :case_sensitive => false
 
   #


### PR DESCRIPTION
Changes the approach taken by https://github.com/rapid7/metasploit-credential/pull/178/files

We're still on Rails 7.0.8, so swapping to the new `coder` kwarg is a noop for our older Rails version. Changing the approach for now.