### PR TITLE
Support rails 7.1

### DIFF
--- a/app/models/metasploit/credential/krb_enc_key.rb
+++ b/app/models/metasploit/credential/krb_enc_key.rb
@@ -73,7 +73,12 @@ class Metasploit::Credential::KrbEncKey < Metasploit::Credential::PasswordHash
   # Callbacks
   #
 
-  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
+  else
+    serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  end
+
   validates_uniqueness_of :data, :case_sensitive => false
 
   #

--- a/app/models/metasploit/credential/ntlm_hash.rb
+++ b/app/models/metasploit/credential/ntlm_hash.rb
@@ -60,7 +60,11 @@ class Metasploit::Credential::NTLMHash < Metasploit::Credential::ReplayableHash
 
   # Hash results are always downcased when stored in the database
   # This serializer allows for ORM to search in a case-insensitive
-  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
+  else
+    serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  end
 
   #
   # Validations

--- a/app/models/metasploit/credential/postgres_md5.rb
+++ b/app/models/metasploit/credential/postgres_md5.rb
@@ -13,7 +13,11 @@ class Metasploit::Credential::PostgresMD5 < Metasploit::Credential::ReplayableHa
   # Callbacks
   #
 
-  serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :data, coder: Metasploit::Credential::CaseInsensitiveSerializer
+  else
+    serialize :data, Metasploit::Credential::CaseInsensitiveSerializer
+  end
   validates_uniqueness_of :data, :case_sensitive => false
 
   #


### PR DESCRIPTION
Support rails 7.1 by fixing the following deprecation warning:

```
DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.
Please pass the coder as a keyword argument:
  serialize :params, coder: #<MetasploitDataModels::Base64Serializer:0x00007f[62](https://github.com/rapid7/metasploit-framework/actions/runs/9475070418/job/26105783525?pr=19254#step:7:63)ee438228>
 (called from <top (required)> at /home/runner/work/metasploit-framework/metasploit-framework/config/environment.rb:4)
```