### PR TITLE
Remove hardcoded secret

### DIFF
--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = '16a85a222f50e7c811e690a75a82762c72861d5c5afb50e89b490c4186f2f4e3cc95f6c94c8529b6cfd32e3705b71af18dcedb5445cdd9e1fd64c293c1fd92d6'


### PR DESCRIPTION
Resolves a snyk issue with a hardcoded secret, not a valid security concern since it's in the test suite but it can be removed anyway, I was able to remove the whole file since `secret_token` hasn't been in use since migrating to rails 4 

https://guides.rubyonrails.org/v4.0.8/upgrading_ruby_on_rails.html#:~:text=%23%20end-,2.6%20Action%20Pack,-Rails%204.0%20introduces