### PR TITLE
Add CA and ADCS Template metadata to Pkcs12

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
         metasploit/credential/pkcs12:
           attributes:
             data:
-              format: "is not a Base64 encoded pkcs12 file without a password"
+              format: "is not a serialized data containing Base64 encoded pkcs12 file without a password and metadata"
         metasploit/credential/ssh_key:
           attributes:
             data:

--- a/spec/factories/metasploit/credential/pkcs12.rb
+++ b/spec/factories/metasploit/credential/pkcs12.rb
@@ -10,28 +10,57 @@ FactoryBot.define do
       subject { '/C=BE/O=Test/OU=Test/CN=Test' }
       # the cert issuer
       issuer { '/C=BE/O=Test/OU=Test/CN=Test' }
+      # the base64-encoded cert
+      pkcs12_base64 {
+        password = ''
+        pkcs12_name = ''
+
+        private_key = OpenSSL::PKey::RSA.new(key_size)
+        public_key = private_key.public_key
+
+        cert = OpenSSL::X509::Certificate.new
+        cert.subject = OpenSSL::X509::Name.parse(subject)
+        cert.issuer = OpenSSL::X509::Name.parse(issuer)
+        cert.not_before = Time.now
+        cert.not_after = Time.now + 365 * 24 * 60 * 60
+        cert.public_key = public_key
+        cert.serial = 0x0
+        cert.version = 2
+        cert.sign(private_key, OpenSSL::Digest.new(signing_algorithm))
+
+        pkcs12 = OpenSSL::PKCS12.create(password, pkcs12_name, private_key, cert)
+        Base64.strict_encode64(pkcs12.to_der)
+      }
     end
 
-    data {
-      password = ''
-      pkcs12_name = ''
-
-      private_key = OpenSSL::PKey::RSA.new(key_size)
-      public_key = private_key.public_key
-
-      cert = OpenSSL::X509::Certificate.new
-      cert.subject = OpenSSL::X509::Name.parse(subject)
-      cert.issuer = OpenSSL::X509::Name.parse(issuer)
-      cert.not_before = Time.now
-      cert.not_after = Time.now + 365 * 24 * 60 * 60
-      cert.public_key = public_key
-      cert.serial = 0x0
-      cert.version = 2
-      cert.sign(private_key, OpenSSL::Digest.new(signing_algorithm))
-
-      pkcs12 = OpenSSL::PKCS12.create(password, pkcs12_name, private_key, cert)
-      pkcs12_base64 = Base64.strict_encode64(pkcs12.to_der)
-      pkcs12_base64
-    }
+    data { Metasploit::Credential::Pkcs12.build_data(pkcs12: pkcs12_base64) }
   end
+
+  factory :metasploit_credential_pkcs12_with_ca, parent: :metasploit_credential_pkcs12 do
+    transient do
+      # The CA that issued the certificate
+      ca { "test-ca" }
+    end
+
+    data { Metasploit::Credential::Pkcs12.build_data(pkcs12: pkcs12_base64, ca: ca) }
+  end
+
+  factory :metasploit_credential_pkcs12_with_adcs_template, parent: :metasploit_credential_pkcs12 do
+    transient do
+      # The certificate template used to issue the certificate
+      adcs_template { "User" }
+    end
+
+    data { Metasploit::Credential::Pkcs12.build_data(pkcs12: pkcs12_base64, adcs_template: adcs_template) }
+  end
+
+  factory :metasploit_credential_pkcs12_with_ca_and_adcs_template, parent: :metasploit_credential_pkcs12 do
+    transient do
+      ca { "test-ca" }
+      adcs_template { "User" }
+    end
+
+    data { Metasploit::Credential::Pkcs12.build_data(pkcs12: pkcs12_base64, ca: ca, adcs_template: adcs_template) }
+  end
+
 end

--- a/spec/models/metasploit/credential/pkcs12_spec.rb
+++ b/spec/models/metasploit/credential/pkcs12_spec.rb
@@ -1,10 +1,36 @@
 RSpec.describe Metasploit::Credential::Pkcs12, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
 
+  it { is_expected.to be_a Metasploit::Credential::Private }
+
   context 'factories' do
     context 'metasploit_credential_pkcs12' do
       subject(:metasploit_credential_pkcs12) do
         FactoryBot.build(:metasploit_credential_pkcs12)
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_credential_pkcs12_with_ca' do
+      subject(:metasploit_credential_pkcs12_with_ca) do
+        FactoryBot.build(:metasploit_credential_pkcs12_with_ca)
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_credential_pkcs12_with_adcs_template' do
+      subject(:metasploit_credential_pkcs12_with_adcs_template) do
+        FactoryBot.build(:metasploit_credential_pkcs12_with_adcs_template)
+      end
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'metasploit_credential_pkcs12_with_ca_and_adcs_template' do
+      subject(:metasploit_credential_pkcs12_with_ca_and_adcs_template) do
+        FactoryBot.build(:metasploit_credential_pkcs12_with_ca_and_adcs_template)
       end
 
       it { is_expected.to be_valid }
@@ -104,6 +130,226 @@ RSpec.describe Metasploit::Credential::Pkcs12, type: :model do
 
           it { is_expected.to include(error) }
         end
+      end
+
+      context '#data_format' do
+        subject(:errors) { pkcs12.errors }
+
+        before(:example) do
+          allow(pkcs12).to receive(:data).and_return(data)
+          pkcs12.valid?
+        end
+
+        # Wrong data
+        context 'with empty data' do
+          let(:data) { '' }
+          it { is_expected.to be_added(:data, :format) }
+        end
+
+        context 'with an empty pkcs12 cert' do
+          let(:data) { 'msf_pkcs12::ca:template' }
+          it { is_expected.to be_added(:data, :format) }
+        end
+
+        context 'with missing fields separated by :' do
+          let(:data) { 'msf_pkcs12:pkcs12_cert:ca' }
+          it { is_expected.to be_added(:data, :format) }
+        end
+
+        context 'with a wrong header' do
+          let(:data) { 'msf_krbenckey:pkcs12_cert:ca' }
+          it { is_expected.to be_added(:data, :format) }
+        end
+
+        # Good data
+        context 'with a correct pkcs12 cert' do
+          let(:data) { 'msf_pkcs12:pkcs12_cert::' }
+          it { is_expected.to_not be_added(:data, :format) }
+        end
+
+        context 'with a CA' do
+          let(:data) { 'msf_pkcs12:pkcs12_cert:ca:' }
+          it { is_expected.to_not be_added(:data, :format) }
+        end
+
+        context 'with an ADCS template' do
+          let(:data) { 'msf_pkcs12:pkcs12_cert::adcs_template' }
+          it { is_expected.to_not be_added(:data, :format) }
+        end
+
+        context 'with both a CA and an ADCS template' do
+          let(:data) { 'msf_pkcs12:pkcs12_cert:ca:adcs_template' }
+          it { is_expected.to_not be_added(:data, :format) }
+        end
+      end
+    end
+  end
+
+  context 'self.build_data' do
+    let(:pkcs12_cert) { 'mycert' }
+    let(:ca) { 'myca' }
+    let(:adcs_template) { 'mytemplate' }
+
+    subject(:serialized_data) { described_class.build_data(**args) }
+
+    context 'with only pkcs12 cert' do
+      let(:args) { { pkcs12: pkcs12_cert } }
+      it { is_expected.to eq("msf_pkcs12:#{pkcs12_cert}::") }
+    end
+
+    context 'with pkcs12 cert and CA' do
+      let(:args) { { pkcs12: pkcs12_cert, ca: ca } }
+      it { is_expected.to eq("msf_pkcs12:#{pkcs12_cert}:#{ca}:") }
+    end
+
+    context 'with pkcs12 cert and ADCS template' do
+      let(:args) { { pkcs12: pkcs12_cert, adcs_template: adcs_template } }
+      it { is_expected.to eq("msf_pkcs12:#{pkcs12_cert}::#{adcs_template}") }
+    end
+
+    context 'with pkcs12 cert, CA and ADCS template' do
+      let(:args) { { pkcs12: pkcs12_cert, ca: ca, adcs_template: adcs_template } }
+      it { is_expected.to eq("msf_pkcs12:#{pkcs12_cert}:#{ca}:#{adcs_template}") }
+    end
+
+    context 'without pkcs12 cert' do
+      let(:args) { { ca: ca, adcs_template: adcs_template } }
+      it 'raises the expected exception' do
+        expect { serialized_data }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with an empty CA' do
+      let(:args) { { pkcs12: pkcs12_cert, ca: '' } }
+      it 'raises the expected exception' do
+        expect { serialized_data }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with an empty ADCS template' do
+      let(:args) { { pkcs12: pkcs12_cert, ca: '', adcs_template: '' } }
+      it 'raises the expected exception' do
+        expect { serialized_data }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  context '#pkcs12' do
+    it 'returns the base64 encoded pkcs12' do
+      cert = 'mycert'
+      data = "msf_pkcs12:#{cert}:myca:mytemplate"
+      pkcs12 = FactoryBot.build(:metasploit_credential_pkcs12, data: data)
+      expect(pkcs12.pkcs12).to eq(cert)
+    end
+  end
+
+  context '#ca' do
+    it 'returns the CA' do
+      ca = 'myca'
+      data = "msf_pkcs12:mycert:#{ca}:mytemplate"
+      pkcs12 = FactoryBot.build(:metasploit_credential_pkcs12, data: data)
+      expect(pkcs12.ca).to eq(ca)
+    end
+  end
+
+  context '#ca' do
+    it 'returns the CA' do
+      adcs_template = 'mytemplate'
+      data = "msf_pkcs12:mycert:ca:#{adcs_template}"
+      pkcs12 = FactoryBot.build(:metasploit_credential_pkcs12, data: data)
+      expect(pkcs12.adcs_template).to eq(adcs_template)
+    end
+  end
+
+  context '#openssl_pkcs12' do
+    subject { FactoryBot.build(:metasploit_credential_pkcs12).openssl_pkcs12 }
+
+    it { is_expected.to be_a OpenSSL::PKCS12 }
+
+    it 'raises an exception if data is not a base64-encoded certificate' do
+      expect {
+        FactoryBot.build(:metasploit_credential_pkcs12, data: 'msf_pkcs12:wrong_cert::').openssl_pkcs12
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'returns the expected OpenSSL::PKCS12' do
+      subject = '/C=FR/O=Yeah/OU=Yeah/CN=Yeah'
+      issuer = '/C=FR/O=Issuer1/OU=Issuer1/CN=Issuer1'
+      pkcs12 = FactoryBot.build(
+        :metasploit_credential_pkcs12,
+        signing_algorithm: 'SHA512',
+        subject: subject,
+        issuer: issuer
+      )
+      openssl_pkcs12 = pkcs12.openssl_pkcs12
+      expect(openssl_pkcs12.certificate.signature_algorithm).to eq("sha512WithRSAEncryption")
+      expect(openssl_pkcs12.certificate.subject.to_s).to eq(subject)
+      expect(openssl_pkcs12.certificate.issuer.to_s).to eq(issuer)
+    end
+  end
+
+  context '#to_s' do
+    let(:subject) { '/C=FR/O=Yeah/OU=Yeah/CN=Yeah' }
+    let(:issuer) { '/C=FR/O=Issuer1/OU=Issuer1/CN=Issuer1' }
+    let(:ca) { 'myca' }
+    let(:adcs_template) { 'mytemplate' }
+
+    context 'with the pkcs21 only' do
+      it 'returns the expected string' do
+        ca = 'myca'
+        adcs_template = 'mytemplate'
+        pkcs12 = FactoryBot.build(
+          :metasploit_credential_pkcs12,
+          subject: subject,
+          issuer: issuer
+        )
+        expect(pkcs12.to_s).to eq("subject:#{subject},issuer:#{issuer}")
+      end
+    end
+
+    context 'with the pkcs21 and the ca' do
+      it 'returns the expected string' do
+        pkcs12 = FactoryBot.build(
+          :metasploit_credential_pkcs12_with_ca,
+          subject: subject,
+          issuer: issuer,
+          ca: ca
+        )
+        expect(pkcs12.to_s).to eq("subject:#{subject},issuer:#{issuer},CA:#{ca}")
+      end
+    end
+
+    context 'with the pkcs21 and the ADCS template' do
+      it 'returns the expected string' do
+        pkcs12 = FactoryBot.build(
+          :metasploit_credential_pkcs12_with_adcs_template,
+          subject: subject,
+          issuer: issuer,
+          adcs_template: adcs_template
+        )
+        expect(pkcs12.to_s).to eq("subject:#{subject},issuer:#{issuer},ADCS_template:#{adcs_template}")
+      end
+    end
+
+    context 'with the pkcs21, the CA and the ADCS template' do
+      it 'returns the expected string' do
+        subject = '/C=FR/O=Yeah/OU=Yeah/CN=Yeah'
+        issuer = '/C=FR/O=Issuer1/OU=Issuer1/CN=Issuer1'
+        pkcs12 = FactoryBot.build(
+          :metasploit_credential_pkcs12_with_ca_and_adcs_template,
+          subject: subject,
+          issuer: issuer,
+          ca: ca,
+          adcs_template: adcs_template
+        )
+        expect(pkcs12.to_s).to eq("subject:#{subject},issuer:#{issuer},CA:#{ca},ADCS_template:#{adcs_template}")
+      end
+    end
+
+    context 'with no data' do
+      it 'returns an empty string' do
+        pkcs12 = FactoryBot.build(:metasploit_credential_pkcs12, data: nil)
+        expect(pkcs12.to_s).to eq('')
       end
     end
   end


### PR DESCRIPTION
This adds the following metadata to Pkcs12:
- CA: the certificate authority that issued the certificate.
- ADCS Template: the AD CS certificate template used to issue the certificate.

The data is now serialized in the Pkcs12's `data` field with the following format: `msf_pkcs12:<base64 cert>:<ca>:<ADCS template>`.