### PR TITLE
Update upload artifact version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -86,7 +86,7 @@ jobs:
           bundle exec rake yard
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.ruby }}
           path: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.ruby }}
+          name: coverage-${{ matrix.os }}-${{ matrix.ruby }}
           path: |
             coverage/
           retention-days: 1

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ group :development do
 end
 
 group :development, :test do
+  # Temporary, remove once the Rails 7.1 update is complete
+  # see: https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
+  gem 'concurrent-ruby', '1.3.4'
+
   # Hash password for Metasploit::Credential::PasswordHash factories
   gem 'bcrypt'
   # supplies factories for producing model instance for specs


### PR DESCRIPTION
To resolve the following issue:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```