### PR TITLE
Updates verify workflow to use shared pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,70 +25,13 @@ on:
       - '*'
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
-
-    services:
-      postgres:
-        image: postgres:9.6
-        ports: ["5432:5432"]
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    strategy:
-      fail-fast: true
-      matrix:
-        ruby:
-          - '2.7'
-          - '3.0'
-          - '3.1'
-          - '3.2'
-        os:
-          - ubuntu-22.04
-          - ubuntu-latest
-        exclude:
-          - { os: ubuntu-latest, ruby: '2.7' }
-          - { os: ubuntu-latest, ruby: '3.0' }
-
-    env:
-      RAILS_ENV: test
-
-    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
-    steps:
-      - name: Install system dependencies
-        run: sudo apt-get install libpcap-dev graphviz
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '${{ matrix.ruby }}'
-          bundler-cache: true
-
-      - name: Test
-        run: |
-          cp spec/dummy/config/database.yml.github_actions spec/dummy/config/database.yml
-          bundle exec rake --version
-          bundle exec rake db:create db:migrate
-
-          # Disabling this check because it is proving unreliable
-          # git diff --exit-code spec/dummy/db/structure.sql
-          bundle exec rake spec
-          bundle exec rake yard
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.os }}-${{ matrix.ruby }}
-          path: |
-            coverage/
-          retention-days: 1
+  build:
+    uses: rapid7/metasploit-framework/.github/workflows/shared_gem_verify_rails.yml@master
+    with:
+      dependencies: '["libpcap-dev", "graphviz"]'
+      test_commands: |
+        cp spec/dummy/config/database.yml.github_actions spec/dummy/config/database.yml
+        bundle exec rake --version
+        bundle exec rake db:create db:migrate
+        bundle exec rake spec
+        bundle exec rake yard

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/gem_tasks'
 require 'bundler/setup'
+require 'yard'
 
 begin
   require 'rdoc/task'

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -38,5 +38,16 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-ssh'
 
   s.add_runtime_dependency 'pg'
+
+  # mutex_m and bigdecimal are not part of the default gems starting from Ruby 3.4.0: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
+  %w[
+    bigdecimal
+    csv
+    drb
+    mutex_m
+  ].each do |library|
+    s.add_runtime_dependency library
+  end
+
   s.platform = Gem::Platform::RUBY
 end

--- a/yard/templates/default/module/html/setup.rb
+++ b/yard/templates/default/module/html/setup.rb
@@ -91,8 +91,8 @@ def namespace_domain_models
   Metasploit::Credential::Engine.instance.eager_load!
 
   ApplicationRecord.descendants.select { |klass|
-    klass.parents.any? { |parent|
-      parent.name == object.title
+    klass.ancestors.any? { |ancestor|
+      ancestor.name == object.title
     }
   }
 end


### PR DESCRIPTION
This updates this workflow to make use off the shared pipeline added as part of https://github.com/rapid7/metasploit-framework/pull/20001.

Initially this PR will point at these new pipelines on my @cgranleese-r7 repository for testing. Once this is landed, I will rebase this PR.

Related PRs:
- https://github.com/rapid7/metasploit-framework/pull/20001
- https://github.com/rapid7/metasploit-concern/pull/45
- https://github.com/rapid7/metasploit-credential/pull/189
- https://github.com/rapid7/metasploit-model/pull/73
- https://github.com/rapid7/metasploit_data_models/pull/216
- https://github.com/rapid7/rex-core/pull/43
- https://github.com/rapid7/rex-exploitation/pull/46/
- https://github.com/rapid7/rex-mime/pull/9
- https://github.com/rapid7/rex-powershell/pull/45
- https://github.com/rapid7/rex-random_identifier/pull/15
- https://github.com/rapid7/rex-socket/pull/73
- https://github.com/rapid7/rex-sslscan/pull/10
- https://github.com/rapid7/rex-text/pull/73

## Ruby 3.4
I also some dependenices  to the gemspec as it is not part of the default gems starting from Ruby 3.4.0(https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/). This can be pulled out into another PR if that is preferred.

## Verification

- [ ] Ensure CI passes
- [ ] Testing output flows as expected