### PR TITLE
Pin rubyzip version until we can upgrade

### DIFF
--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   # Metasploit::Credential::NTLMHash helper methods
   s.add_runtime_dependency 'rubyntlm'
   # Required for supporting the en masse importation of SSH Keys
-  s.add_runtime_dependency 'rubyzip'
+  s.add_runtime_dependency 'rubyzip', '<3.0.0'
 
   s.add_runtime_dependency 'rex-socket'
 


### PR DESCRIPTION
Ruby zip has released version 3.X which includes breaking changes https://github.com/rubyzip/rubyzip/wiki/Updating-to-version-3.x

I've just pinned the version for now until we have the time to properly investigate the changes and update as necessary