### PR TITLE
Bump rubyzip dependency to ~> 3.0

### DIFF
--- a/lib/metasploit/credential/exporter/core.rb
+++ b/lib/metasploit/credential/exporter/core.rb
@@ -211,7 +211,7 @@ class Metasploit::Credential::Exporter::Core
   def render_zip
     zip_dir_path = Pathname.new(output_final_directory_path)
 
-    Zip::File.open(output_zipfile_path, Zip::File::CREATE) do |zipfile|
+    Zip::File.open(output_zipfile_path, create: true) do |zipfile|
       Dir[File.join(output_final_directory_path, '**', '**')].each do |file|
         file_path = Pathname.new(file)
         path_in_zip = file_path.relative_path_from(zip_dir_path)

--- a/lib/metasploit/credential/importer/zip.rb
+++ b/lib/metasploit/credential/importer/zip.rb
@@ -57,7 +57,7 @@ class Metasploit::Credential::Importer::Zip
   def import!
     ::Zip::File.open(input.path) do |zip_file|
       zip_file.each do |entry|
-        entry.extract(File.join(extracted_zip_directory, entry.name))
+        entry.extract(destination_directory: File.join(extracted_zip_directory))
       end
     end
 
@@ -80,7 +80,7 @@ class Metasploit::Credential::Importer::Zip
   # @return [void]
   def input_is_well_formed
     begin
-      Zip::File.open input.path do |archive|
+      Zip::File.open(input.path) do |archive|
         glob_check  = archive.glob("**#{File::SEPARATOR}#{MANIFEST_FILE_NAME}")
         if glob_check.present?
           true

--- a/lib/metasploit/credential/importer/zip.rb
+++ b/lib/metasploit/credential/importer/zip.rb
@@ -80,7 +80,7 @@ class Metasploit::Credential::Importer::Zip
   # @return [void]
   def input_is_well_formed
     begin
-      Zip::File.open(input.path) do |archive|
+      ::Zip::File.open(input.path) do |archive|
         glob_check  = archive.glob("**#{File::SEPARATOR}#{MANIFEST_FILE_NAME}")
         if glob_check.present?
           true

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   # Metasploit::Credential::NTLMHash helper methods
   s.add_runtime_dependency 'rubyntlm'
   # Required for supporting the en masse importation of SSH Keys
-  s.add_runtime_dependency 'rubyzip', '<3.0.0'
+  s.add_runtime_dependency 'rubyzip', '~> 3.0'
 
   s.add_runtime_dependency 'rex-socket'
 

--- a/metasploit-credential.gemspec
+++ b/metasploit-credential.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   # Metasploit::Credential::NTLMHash helper methods
   s.add_runtime_dependency 'rubyntlm'
   # Required for supporting the en masse importation of SSH Keys
-  s.add_runtime_dependency 'rubyzip', '~> 3.0'
+  s.add_runtime_dependency 'rubyzip', '>= 3.1.1', '< 4.0'
 
   s.add_runtime_dependency 'rex-socket'
 

--- a/spec/factories/metasploit/credential/importer/zips.rb
+++ b/spec/factories/metasploit/credential/importer/zips.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
 
     # Write out zip file
     zip_location = "#{path}.zip"
-    ::Zip::File.open(zip_location, ::Zip::File::CREATE) do |zipfile|
+    ::Zip::File.open(zip_location, create: true) do |zipfile|
       Dir[File.join(path, '**', '**')].each do |file|
         zipfile.add(file.sub(path + '/', ''), file)
       end
@@ -140,7 +140,7 @@ FactoryBot.define do
 
     # Write out zip file
     zip_location = "#{path}.zip"
-    ::Zip::File.open(zip_location, ::Zip::File::CREATE) do |zipfile|
+    ::Zip::File.open(zip_location, create: true) do |zipfile|
       Dir[File.join(path, '**', '**')].each do |file|
         zipfile.add(file.sub(path + '/', ''), file)
       end

--- a/spec/factories/metasploit/credential/importer/zips.rb
+++ b/spec/factories/metasploit/credential/importer/zips.rb
@@ -98,7 +98,7 @@ FactoryBot.define do
 
     # Write out zip file
     zip_location = "#{path}.zip"
-    ::Zip::File.open(zip_location, ::Zip::File::CREATE) do |zipfile|
+    ::Zip::File.open(zip_location, create: true) do |zipfile|
       Dir[File.join(path, '**', '**')].each do |file|
         zipfile.add(file.sub(path + '/', ''), file)
       end

--- a/spec/lib/metasploit/credential/migrator_spec.rb
+++ b/spec/lib/metasploit/credential/migrator_spec.rb
@@ -99,12 +99,14 @@ RSpec.describe Metasploit::Credential::Migrator do
 
         context "when Cred#pass points to a file system path" do
 
-          let(:path_to_ssh_key) do
+          let(:ssh_key_tempfile) do
             t = Tempfile.new('ssh')
             t.write(ssh_key_content)
             t.close
-            t.path
+            t
           end
+
+          let(:path_to_ssh_key) { ssh_key_tempfile.path }
 
           let(:cred) do
             FactoryBot.create(:mdm_cred,
@@ -112,6 +114,10 @@ RSpec.describe Metasploit::Credential::Migrator do
                              ptype: 'ssh_key',
                              pass: path_to_ssh_key
             )
+          end
+
+          after(:example) do
+            ssh_key_tempfile.unlink
           end
 
           before(:example) do


### PR DESCRIPTION
Bumps RubyZip to 3.1.1

This is needed to be able to reliably read and write Zip64 zip files, particularly in the backup routine.

Following changes made to to comply with [breaking changes in RubyZip 3.x](https://github.com/rubyzip/rubyzip/wiki/Updating-to-version-3.x)

- `Metasploit::Credential::Importer::Zip` 
  - destination_directory needs to specified as a path via a named param
- Factory for `Metasploit::Credential::Importer::Zip`
  - ::CREATE constant replaced by named param

Automated test suite passing again.

