### PR TITLE
Update for compatibility with the new Layered Services data model

### DIFF
--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -563,9 +563,8 @@ module Metasploit::Credential::Creation
     workspace_id     = opts.fetch(:workspace_id)
 
     host_object    = Mdm::Host.where(address: address, workspace_id: workspace_id).first_or_create
-    service_object = Mdm::Service.where(host_id: host_object.id, port: port, proto: protocol).first_or_initialize
+    service_object = Mdm::Service.where(host_id: host_object.id, port: port, proto: protocol, name: service_name).first_or_initialize
 
-    service_object.name  = service_name
     service_object.state = "open"
     service_object.save!
 

--- a/spec/factories/metasploit/credential/importer/pwdumps.rb
+++ b/spec/factories/metasploit/credential/importer/pwdumps.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
   sequence :wellformed_pwdump do |n|
     pwdump_string = <<-EOS
 # LM/NTLM Hashes (1 hashes, 1 services)
-# 192.168.0.2:4567/snmp ()
+# 192.168.0.2:4567/udp (snmp)
 metasploit_credential_public_username1:1:aad3b435b51404eeaad3b435b51404ee:79d2d315bcb541a94d4f094a74b46cb2:::
 
 # SSH Private Keys (1 services, 1 keys)
@@ -26,21 +26,21 @@ metasploit_credential_public_username1:1:aad3b435b51404eeaad3b435b51404ee:79d2d3
 Warning: missing SSH key file 'kljsdlkfjfkl;jasdf;lkasjdf;lkjasdf;lkjasdf;lkj'.
 
 # Hashes (2 hashes, 2 services)
-# 192.168.0.2:4567/tcp (snmp)
+# 192.168.0.2:4567/udp (snmp)
 metasploit_credential_public_username1:40bdee771d42eb80d47a7d34ed7fc0a318927197:::
 
-# 192.168.0.3:4567/tcp (snmp)
+# 192.168.0.3:4567/udp (snmp)
 metasploit_credential_public_username2:1654f171e0123b54272d82fb7e94bdf214a9b2a4:::
 
 #  Plaintext Passwords (2 hashes, 2 services)
-# 192.168.0.2:4567/tcp (snmp)
+# 192.168.0.2:4567/udp (snmp)
 metasploit_credential_public_username1 metasploit_credential_password2
 
-# 192.168.0.3:4567/tcp (snmp)
+# 192.168.0.3:4567/udp (snmp)
 metasploit_credential_public_username2 metasploit_credential_password3
 
 # Postgres MD5 Hashes (1 hashes, 1 services)
-# 192.168.0.2:5432/postgres ()
+# 192.168.0.2:5432/tcp (postgres)
 metasploit_credential_public_username1:md53175bce1d3201d16594cebf9d7eb3f9d
   EOS
   StringIO.new(pwdump_string)

--- a/spec/lib/metasploit/credential/creation_spec.rb
+++ b/spec/lib/metasploit/credential/creation_spec.rb
@@ -610,7 +610,7 @@ RSpec.describe Metasploit::Credential::Creation do
             origin_type: :service
         }
         host = FactoryBot.create(:mdm_host, address: opts[:address], workspace_id: opts[:workspace_id])
-        FactoryBot.create(:mdm_service, host_id: host.id, port: opts[:port], proto: opts[:protocol])
+        FactoryBot.create(:mdm_service, host_id: host.id, port: opts[:port], proto: opts[:protocol], name: opts[:service_name])
         expect { test_object.create_credential_origin_service(opts)}.to_not change{Mdm::Service.count }
       end
     end


### PR DESCRIPTION
This PR updates the service lookup in `#create_credential_service` to also include the service name. This change is needed since now the service name defines a unique service. Services with the same `host`, `port` and `proto` but with different names a now considered separate services. Note that this also applies to the new `resource` field. I haven't added the `resource` in the lookup since it doesn't seem to be necessary for now. Please, let me know if you think otherwise.

Some considerations:
- a service without name is still possible (the `name` field is `nil`) and the same rule applies. Two services with the same `host`, `port` and `proto`, but one with a name and the other without, will be considered as two separate services.
- a service without resource defaults to an empty JSON `{}` and the same rule applies. Two services with the same `host`, `port`, `proto` and `name`, but one with a specific resource and the other without (empty JSON), will be considered as two separate services.

This PR also update the `pwdump` file to import in specs. The format was not parsed correctly by the `pwdump` parser and caused unexpected service creations. I tried to keep it consistent with the original regex:
```
# <IP address>:<port>/<proto> (<service name>)
```
