### PR TITLE
Allow a specific service to be used

### DIFF
--- a/lib/metasploit/credential/creation.rb
+++ b/lib/metasploit/credential/creation.rb
@@ -413,6 +413,8 @@ module Metasploit::Credential::Creation
   # If there is not a matching `Mdm::Host` it will create it. If there is not a matching
   # `Mdm::Service` it will create that too.
   #
+  # @option opts [Mdm::Service] :service The service to use instead of creating one
+  # @option opts [Fixnum] :service_id The ID of the `Mdm::Service` to link this Origin to
   # @option opts [String] :address The address of the `Mdm::Host` to link this Origin to
   # @option opts [Fixnum] :port The port number of the `Mdm::Service` to link this Origin to
   # @option opts [String] :service_name The service name to use for the `Mdm::Service`
@@ -423,8 +425,13 @@ module Metasploit::Credential::Creation
   # @return [Metasploit::Credential::Origin::Service] The created {Metasploit::Credential::Origin::Service} object
   def create_credential_origin_service(opts={})
     return nil unless active_db?
+
     module_fullname  = opts.fetch(:module_fullname)
-    service_object = create_credential_service(opts)
+    if (service_id = opts[:service_id] || opts[:service].try(:id))
+      service_object = Mdm::Service.where(id: service_id).first
+    else
+      service_object = create_credential_service(opts)
+    end
     return nil if service_object.nil?
 
     retry_transaction do

--- a/spec/lib/metasploit/credential/creation_spec.rb
+++ b/spec/lib/metasploit/credential/creation_spec.rb
@@ -652,6 +652,49 @@ RSpec.describe Metasploit::Credential::Creation do
         expect{ test_object.create_credential_origin_service(opts)}.to raise_error KeyError
       end
     end
+
+    context 'when :service is provided' do
+      it 'uses the given service object and does not create a new Mdm::Service' do
+        host = FactoryBot.create(:mdm_host, workspace: workspace)
+        existing_service = FactoryBot.create(:mdm_service, host: host)
+        opts = {
+          service: existing_service,
+          module_fullname: 'auxiliary/scanner/smb/smb_login',
+          origin_type: :service
+        }
+        expect { test_object.create_credential_origin_service(opts) }.to_not change { Mdm::Service.count }
+        origin = test_object.create_credential_origin_service(opts)
+        expect(origin.service_id).to eq(existing_service.id)
+      end
+    end
+
+    context 'when :service_id is provided' do
+      context 'and the ID corresponds to an existing Mdm::Service' do
+        it 'uses that service and does not create a new Mdm::Service' do
+          host = FactoryBot.create(:mdm_host, workspace: workspace)
+          existing_service = FactoryBot.create(:mdm_service, host: host)
+          opts = {
+            service_id: existing_service.id,
+            module_fullname: 'auxiliary/scanner/smb/smb_login',
+            origin_type: :service
+          }
+          expect { test_object.create_credential_origin_service(opts) }.to_not change { Mdm::Service.count }
+          origin = test_object.create_credential_origin_service(opts)
+          expect(origin.service_id).to eq(existing_service.id)
+        end
+      end
+
+      context 'and the ID does not correspond to an existing Mdm::Service' do
+        it 'returns nil' do
+          opts = {
+            service_id: 0,
+            module_fullname: 'auxiliary/scanner/smb/smb_login',
+            origin_type: :service
+          }
+          expect(test_object.create_credential_origin_service(opts)).to be_nil
+        end
+      end
+    end
   end
 
   context '#create_credential_origin_session' do


### PR DESCRIPTION
This allows credentials to be reported with explicit services. In order to show up in Metasploit's `creds` command output, the origin [must be a `Metasploit::Credential::Origin::Service` or `Metasploit::Credential::Origin::Session` instance](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/ui/console/command_dispatcher/creds.rb#L601), an `Mdm::Service` can't be used. I think this is because it needs to be associated with a module too which is fine, mo info mo betta. This does however complicate the pattern where a module has a service that it has reported, then it's obtained a credential from that service such as a certificate from MS-ICPR or AD CS Web Enrollment. In that case, the Mdm::Service object could be passed as the origin but then the information is omitted from the `creds` command. This allows a caller to pass the `Mdm::Service` as the `:service` argument, and when it is it's used instead of taking the `opts` to create a new service instance.

If a `:service_id` is specified, it takes precedence. Ultimately, it's the ID that's used to create the `Metasploit::Credential::Origin::Service` instance.